### PR TITLE
Add network status monitoring and indicator

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,8 @@ import dotenv from "dotenv";
 import { campaignRouter } from "./routes/campaign.routes";
 import { rewardRouter } from "./routes/reward.routes";
 import { startIndexer } from "./indexer/indexer";
+import { rpcServer } from "./soroban";
+import { pool } from "./db";
 
 dotenv.config();
 
@@ -11,7 +13,44 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
-app.get("/health", (_req, res) => res.json({ status: "ok" }));
+app.get("/health", async (_req, res) => {
+  const startTime = Date.now();
+  const checks: any = {
+    stellar: { reachable: false, latency: 0 },
+    database: { connected: false, responseTime: 0 },
+    indexer: { running: true }
+  };
+
+  // Check Stellar network
+  try {
+    const stellarStart = Date.now();
+    await rpcServer.getHealth();
+    checks.stellar.reachable = true;
+    checks.stellar.latency = Date.now() - stellarStart;
+  } catch (err) {
+    checks.stellar.reachable = false;
+  }
+
+  // Check database
+  try {
+    const dbStart = Date.now();
+    await pool.query('SELECT 1');
+    checks.database.connected = true;
+    checks.database.responseTime = Date.now() - dbStart;
+  } catch (err) {
+    checks.database.connected = false;
+  }
+
+  const allHealthy = checks.stellar.reachable && checks.database.connected;
+  const status = allHealthy ? 'healthy' : (checks.stellar.reachable || checks.database.connected) ? 'degraded' : 'unhealthy';
+
+  res.json({
+    status,
+    checks,
+    timestamp: new Date().toISOString(),
+    uptime: process.uptime()
+  });
+});
 
 app.use("/campaigns", campaignRouter);
 app.use("/", rewardRouter);

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -6,14 +6,19 @@ import { api, Campaign, Reward } from "@/lib/api";
 import { claimReward, redeemReward } from "@/lib/soroban";
 import { CampaignCard } from "@/components/CampaignCard";
 import { RewardList } from "@/components/RewardList";
+import { NetworkBanner } from "@/components/NetworkBanner";
+import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 
 export default function DashboardPage() {
   const { publicKey } = useWallet();
+  const { health } = useNetworkStatus();
   const [campaigns, setCampaigns] = useState<Campaign[]>([]);
   const [rewards, setRewards] = useState<Reward[]>([]);
   const [claimingId, setClaimingId] = useState<number | null>(null);
   const [redeemingId, setRedeemingId] = useState<string | null>(null);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  const networkDisabled = health.status === 'unreachable';
 
   useEffect(() => {
     api.getCampaigns().then((r) => setCampaigns(r.campaigns)).catch(console.error);
@@ -26,6 +31,7 @@ export default function DashboardPage() {
 
   const handleClaim = async (campaignId: number) => {
     if (!publicKey) return setMessage({ type: "error", text: "Connect your wallet first" });
+    if (networkDisabled) return setMessage({ type: "error", text: "Network is unreachable" });
     setClaimingId(campaignId);
     setMessage(null);
     try {
@@ -42,6 +48,7 @@ export default function DashboardPage() {
 
   const handleRedeem = async (reward: Reward) => {
     if (!publicKey) return;
+    if (networkDisabled) return setMessage({ type: "error", text: "Network is unreachable" });
     setRedeemingId(reward.id);
     setMessage(null);
     try {
@@ -59,6 +66,8 @@ export default function DashboardPage() {
   return (
     <div>
       <h1 className="page-title">Dashboard</h1>
+
+      <NetworkBanner health={health} />
 
       {message && (
         <div className={`alert alert-${message.type}`}>{message.text}</div>
@@ -78,7 +87,7 @@ export default function DashboardPage() {
               <CampaignCard
                 key={c.id}
                 campaign={c}
-                onClaim={handleClaim}
+                onClaim={networkDisabled ? undefined : handleClaim}
                 claiming={claimingId === c.id}
               />
             ))}
@@ -91,7 +100,7 @@ export default function DashboardPage() {
           <h2 className="section-title">My Rewards</h2>
           <RewardList
             rewards={rewards}
-            onRedeem={handleRedeem}
+            onRedeem={networkDisabled ? undefined : handleRedeem}
             redeeming={redeemingId}
           />
         </section>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -117,3 +117,101 @@ body {
 }
 .stat-value { font-size: 2rem; font-weight: 700; color: #7c6af7; }
 .stat-label { font-size: 0.8rem; color: #64748b; margin-top: 4px; }
+
+/* ── Network Status ───────────────────────────────────────────────────────── */
+.network-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.875rem;
+  cursor: help;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.status-dot.connected {
+  background-color: #10b981;
+  box-shadow: 0 0 0 2px rgba(16, 185, 129, 0.2);
+}
+
+.status-dot.degraded {
+  background-color: #f59e0b;
+  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2);
+}
+
+.status-dot.unreachable {
+  background-color: #ef4444;
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2);
+}
+
+/* Accessibility: Add symbols for color-blind users */
+.status-dot.connected::after {
+  content: '✓';
+  position: absolute;
+  top: -1px;
+  left: 1px;
+  font-size: 8px;
+  color: white;
+  font-weight: bold;
+}
+
+.status-dot.degraded::after {
+  content: '!';
+  position: absolute;
+  top: -2px;
+  left: 2px;
+  font-size: 10px;
+  color: white;
+  font-weight: bold;
+}
+
+.status-dot.unreachable::after {
+  content: '✕';
+  position: absolute;
+  top: -1px;
+  left: 1px;
+  font-size: 8px;
+  color: white;
+  font-weight: bold;
+}
+
+.status-text {
+  color: #94a3b8;
+  font-size: 0.875rem;
+}
+
+.network-banner {
+  background-color: #fef3c7;
+  color: #92400e;
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid #fbbf24;
+}
+
+.network-banner.error {
+  background-color: #fee2e2;
+  color: #991b1b;
+  border-color: #fca5a5;
+}
+
+.banner-icon {
+  font-size: 1.2rem;
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .status-text {
+    display: none;
+  }
+}
+

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,30 +1,40 @@
+"use client";
+
 import type { Metadata } from "next";
 import { WalletProvider } from "@/context/WalletContext";
 import { WalletConnector } from "@/components/WalletConnector";
+import { NetworkStatusIndicator } from "@/components/NetworkStatusIndicator";
+import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import "./globals.css";
-
-export const metadata: Metadata = {
-  title: "SorobanLoyalty",
-  description: "On-chain loyalty platform on Stellar",
-};
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
         <WalletProvider>
-          <header className="site-header">
-            <a href="/" className="logo">SorobanLoyalty</a>
-            <nav>
-              <a href="/dashboard">Dashboard</a>
-              <a href="/merchant">Merchant</a>
-              <a href="/analytics">Analytics</a>
-            </nav>
-            <WalletConnector />
-          </header>
-          <main className="site-main">{children}</main>
+          <LayoutContent>{children}</LayoutContent>
         </WalletProvider>
       </body>
     </html>
+  );
+}
+
+function LayoutContent({ children }: { children: React.ReactNode }) {
+  const { health } = useNetworkStatus();
+
+  return (
+    <>
+      <header className="site-header">
+        <a href="/" className="logo">SorobanLoyalty</a>
+        <nav>
+          <a href="/dashboard">Dashboard</a>
+          <a href="/merchant">Merchant</a>
+          <a href="/analytics">Analytics</a>
+        </nav>
+        <NetworkStatusIndicator health={health} />
+        <WalletConnector />
+      </header>
+      <main className="site-main">{children}</main>
+    </>
   );
 }

--- a/frontend/src/components/NetworkBanner.tsx
+++ b/frontend/src/components/NetworkBanner.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { NetworkHealth } from "@/hooks/useNetworkStatus";
+
+interface Props {
+  health: NetworkHealth;
+}
+
+export function NetworkBanner({ health }: Props) {
+  const { status } = health;
+
+  if (status === 'connected') return null;
+
+  const getMessage = () => {
+    if (status === 'degraded') {
+      return 'Network connection is experiencing issues. Some features may be limited.';
+    }
+    return 'Unable to connect to the network. Transactions are currently disabled.';
+  };
+
+  return (
+    <div className={`network-banner ${status === 'unreachable' ? 'error' : ''}`} role="alert">
+      <span className="banner-icon" aria-hidden="true">⚠</span>
+      <span>{getMessage()}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/NetworkStatusIndicator.tsx
+++ b/frontend/src/components/NetworkStatusIndicator.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { NetworkHealth } from "@/hooks/useNetworkStatus";
+
+interface Props {
+  health: NetworkHealth;
+}
+
+export function NetworkStatusIndicator({ health }: Props) {
+  const { status, lastChecked } = health;
+
+  const getStatusText = () => {
+    switch (status) {
+      case 'connected': return 'Connected';
+      case 'degraded': return 'Network Issues';
+      case 'unreachable': return 'Offline';
+    }
+  };
+
+  const formatLastChecked = () => {
+    if (!lastChecked) return 'Checking...';
+    const now = new Date();
+    const diff = Math.floor((now.getTime() - lastChecked.getTime()) / 1000);
+    
+    if (diff < 60) return `${diff}s ago`;
+    if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+    return lastChecked.toLocaleTimeString();
+  };
+
+  return (
+    <div className="network-status" title={`Last checked: ${formatLastChecked()}`}>
+      <span className={`status-dot ${status}`} aria-label={getStatusText()} />
+      <span className="status-text">{getStatusText()}</span>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useNetworkStatus.ts
+++ b/frontend/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export interface NetworkHealth {
+  status: 'connected' | 'degraded' | 'unreachable';
+  lastChecked: Date | null;
+  stellarNetwork: boolean;
+  backendAPI: boolean;
+  latency?: number;
+}
+
+const CHECK_INTERVAL = 30000; // 30 seconds
+const TIMEOUT = 5000; // 5 seconds
+
+export function useNetworkStatus() {
+  const [health, setHealth] = useState<NetworkHealth>({
+    status: 'connected',
+    lastChecked: null,
+    stellarNetwork: false,
+    backendAPI: false
+  });
+
+  const checkHealth = useCallback(async () => {
+    try {
+      const startTime = Date.now();
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), TIMEOUT);
+
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001'}/health`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        signal: controller.signal
+      });
+
+      clearTimeout(timeoutId);
+      const latency = Date.now() - startTime;
+
+      if (!response.ok) {
+        setHealth({
+          status: 'degraded',
+          lastChecked: new Date(),
+          stellarNetwork: false,
+          backendAPI: false,
+          latency
+        });
+        return;
+      }
+
+      const data = await response.json();
+      const stellarReachable = data.checks?.stellar?.reachable || false;
+      const dbConnected = data.checks?.database?.connected || false;
+
+      let status: NetworkHealth['status'] = 'connected';
+      if (!stellarReachable && !dbConnected) {
+        status = 'unreachable';
+      } else if (!stellarReachable || !dbConnected) {
+        status = 'degraded';
+      }
+
+      setHealth({
+        status,
+        lastChecked: new Date(),
+        stellarNetwork: stellarReachable,
+        backendAPI: true,
+        latency
+      });
+    } catch (error) {
+      setHealth({
+        status: 'unreachable',
+        lastChecked: new Date(),
+        stellarNetwork: false,
+        backendAPI: false
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    // Initial check
+    checkHealth();
+
+    // Periodic checks
+    const intervalId = setInterval(checkHealth, CHECK_INTERVAL);
+
+    return () => clearInterval(intervalId);
+  }, [checkHealth]);
+
+  return { health, checkHealth };
+}


### PR DESCRIPTION
- Enhance /health endpoint with Stellar and database checks
- Add network status indicator in header with green/yellow/red states
- Implement 30-second polling for network health
- Show warning banner when network is degraded
- Disable claim/redeem buttons when network is unreachable
- Add accessible status indicators (color + icon)
- Display last checked time in tooltip

Closes #59