### PR TITLE
Issues/89 90 91 documentation

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,206 @@
+# Smart Contracts — SorobanLoyalty
+
+Three Soroban contracts implement the on-chain loyalty logic. They are deployed to the Stellar network and interact with each other via cross-contract calls.
+
+---
+
+## Contracts Overview
+
+| Contract | Crate | Purpose |
+|---|---|---|
+| `token` | `soroban-loyalty-token` | Fungible LYT token — mint, burn, transfer |
+| `campaign` | `soroban-loyalty-campaign` | Merchants create and manage reward campaigns |
+| `rewards` | `soroban-loyalty-rewards` | Users claim rewards (mints LYT) and redeem them (burns LYT) |
+
+---
+
+## Token Contract (`contracts/token/src/lib.rs`)
+
+### Purpose
+
+Implements a custom fungible token (LYT) with admin-controlled minting. It does **not** implement the full SEP-41 interface — it is purpose-built for the loyalty platform.
+
+### Functions
+
+| Function | Auth required | Description |
+|---|---|---|
+| `initialize(admin, name, symbol, decimals)` | — | One-time setup. Panics if called again. |
+| `mint(to, amount)` | Admin | Mint `amount` LYT to `to`. Amount must be > 0. |
+| `burn(from, amount)` | `from` | Burn `amount` from `from`. Balance must be sufficient. |
+| `transfer(from, to, amount)` | `from` | Transfer `amount` from `from` to `to`. |
+| `balance(addr)` | — | Read balance of `addr`. |
+| `total_supply_view()` | — | Read total token supply. |
+| `admin_address()` | — | Read current admin address. |
+| `name()` / `symbol()` / `decimals()` | — | Read token metadata. |
+| `set_admin(new_admin)` | Admin | Transfer admin role to `new_admin`. |
+
+### Storage Layout
+
+| Key | Storage type | Value type | Description |
+|---|---|---|---|
+| `DataKey::Admin` | Instance | `Address` | Contract admin (minter) |
+| `DataKey::Name` | Instance | `String` | Token name |
+| `DataKey::Symbol` | Instance | `String` | Token symbol |
+| `DataKey::Decimals` | Instance | `u32` | Decimal places |
+| `DataKey::TotalSupply` | Instance | `i128` | Running total supply |
+| `DataKey::Balance(Address)` | Persistent | `i128` | Per-address balance |
+
+### Events
+
+| Topic | Data | Emitted on |
+|---|---|---|
+| `(MINT, "to", to)` | `amount: i128` | Successful mint |
+| `(BURN, "from", from)` | `amount: i128` | Successful burn |
+| `(TRANSFER, "from", from)` | `(to: Address, amount: i128)` | Successful transfer |
+
+---
+
+## Campaign Contract (`contracts/campaign/src/lib.rs`)
+
+### Purpose
+
+Merchants create campaigns that define a reward amount and an expiration timestamp. The rewards contract reads campaign data and increments the claim counter via `record_claim`.
+
+### Functions
+
+| Function | Auth required | Description |
+|---|---|---|
+| `initialize(admin)` | — | One-time setup. Sets admin and seeds `NextId = 1`. |
+| `create_campaign(merchant, reward_amount, expiration)` | `merchant` | Creates a new campaign. Returns the new campaign ID. |
+| `set_active(campaign_id, active)` | Campaign merchant | Activate or deactivate a campaign. |
+| `record_claim(campaign_id)` | — | Increments `total_claimed`. Called by the rewards contract. |
+| `get_campaign(campaign_id)` | — | Returns the full `Campaign` struct. |
+| `is_active(campaign_id)` | — | Returns `true` if `active == true` and not yet expired. |
+
+### Storage Layout
+
+| Key | Storage type | Value type | Description |
+|---|---|---|---|
+| `DataKey::Admin` | Instance | `Address` | Contract admin |
+| `DataKey::NextId` | Instance | `u64` | Auto-increment campaign ID counter |
+| `DataKey::Campaign(u64)` | Persistent | `Campaign` | Campaign data by ID |
+
+#### `Campaign` struct
+
+```rust
+pub struct Campaign {
+    pub id: u64,
+    pub merchant: Address,
+    pub reward_amount: i128,   // LYT amount per claim
+    pub expiration: u64,       // Unix timestamp (seconds)
+    pub active: bool,
+    pub total_claimed: u64,
+}
+```
+
+### Events
+
+| Topic | Data | Emitted on |
+|---|---|---|
+| `(CAM_CRT, "id", id)` | `merchant: Address` | Campaign created |
+| `(CAM_UPD, "id", id)` | `active: bool` | Campaign activated / deactivated |
+
+---
+
+## Rewards Contract (`contracts/rewards/src/lib.rs`)
+
+### Purpose
+
+Entry point for user interactions. `claim_reward` verifies the campaign is active, prevents double-claims, mints LYT to the user, and increments the campaign counter. `redeem_reward` burns LYT from the user.
+
+### Functions
+
+| Function | Auth required | Description |
+|---|---|---|
+| `initialize(admin, token_contract, campaign_contract)` | — | One-time setup. Stores contract addresses. |
+| `claim_reward(user, campaign_id)` | `user` | Claim reward for a campaign. Mints LYT. |
+| `redeem_reward(user, amount)` | `user` | Redeem (burn) `amount` LYT. |
+| `has_claimed_view(user, campaign_id)` | — | Check if `user` has already claimed for `campaign_id`. |
+
+### Storage Layout
+
+| Key | Storage type | Value type | Description |
+|---|---|---|---|
+| `DataKey::Admin` | Instance | `Address` | Contract admin |
+| `DataKey::TokenContract` | Instance | `Address` | Token contract address |
+| `DataKey::CampaignContract` | Instance | `Address` | Campaign contract address |
+| `DataKey::Claimed(Address, u64)` | Persistent | `bool` | Double-claim guard per (user, campaign) |
+
+### Events
+
+| Topic | Data | Emitted on |
+|---|---|---|
+| `(RWD_CLM, "user", user)` | `(campaign_id: u64, amount: i128)` | Reward claimed |
+| `(RWD_RDM, "user", user)` | `amount: i128` | Reward redeemed |
+
+---
+
+## Cross-Contract Interaction Diagram
+
+```
+User
+ │
+ │  claim_reward(user, campaign_id)
+ ▼
+RewardsContract
+ │
+ ├─► CampaignContract.is_active(campaign_id)        [read]
+ ├─► CampaignContract.get_campaign(campaign_id)     [read]
+ ├─► CampaignContract.record_claim(campaign_id)     [write]
+ └─► TokenContract.mint(user, reward_amount)        [write — admin call]
+
+ │  redeem_reward(user, amount)
+ ▼
+RewardsContract
+ └─► TokenContract.burn(user, amount)               [write]
+
+Merchant
+ │
+ │  create_campaign(merchant, reward_amount, expiration)
+ ▼
+CampaignContract                                    [standalone, no cross-calls]
+```
+
+The rewards contract is the **only** caller of `TokenContract.mint`. This is enforced by setting the rewards contract address as the token admin during deployment.
+
+---
+
+## Authorization Model
+
+| Action | Who can call |
+|---|---|
+| Mint LYT | Token admin only (= rewards contract address) |
+| Burn LYT | The token holder (`from.require_auth()`) |
+| Transfer LYT | The sender (`from.require_auth()`) |
+| Create campaign | Any address (becomes the campaign merchant) |
+| Deactivate campaign | The campaign's `merchant` address only |
+| Claim reward | The claiming user (`user.require_auth()`) |
+| Redeem reward | The redeeming user (`user.require_auth()`) |
+| `record_claim` | No auth check — callable by anyone; only increments a counter |
+| `set_admin` (token) | Current token admin |
+
+> `record_claim` has no auth guard by design: it only increments a counter and the rewards contract is the only caller in normal operation. A future improvement would restrict it to the rewards contract address.
+
+---
+
+## Security Assumptions and Invariants
+
+1. **Double-claim prevention** — `DataKey::Claimed(user, campaign_id)` is written to persistent storage *before* the external `mint` call. This prevents reentrancy from allowing a second claim in the same invocation.
+
+2. **Overflow-safe arithmetic** — All additions use `checked_add` / Rust's `overflow-checks = true` in release builds. Subtraction is guarded by explicit balance assertions.
+
+3. **Mint authority** — `TokenContract.mint` requires the caller to be the stored admin. The deploy script sets the rewards contract as admin, so no external party can mint LYT.
+
+4. **Expiration is ledger-time** — `is_active` compares against `env.ledger().timestamp()`, which is the Stellar network ledger close time. It cannot be manipulated by the caller.
+
+5. **One-time initialization** — All three contracts check for the presence of `DataKey::Admin` in instance storage and panic if `initialize` is called a second time.
+
+---
+
+## Known Limitations and Edge Cases
+
+- **`record_claim` is unauthenticated** — any account can call it and inflate `total_claimed`. This is a cosmetic issue (the counter is informational) but should be restricted in a production upgrade.
+- **No campaign update function** — once created, `reward_amount` and `expiration` are immutable. A merchant can only deactivate a campaign, not edit it.
+- **`set_admin` is single-step** — transferring the token admin is immediate with no confirmation step. A two-step transfer (propose + accept) would be safer in production.
+- **No pagination on campaigns** — the contract has no built-in way to enumerate all campaign IDs. The backend indexer tracks them via on-chain events.
+- **LYT is not SEP-41 compliant** — the token does not implement the full Stellar Asset Contract interface, so it cannot be used directly with DEXes or other SEP-41-aware tooling without modification.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,256 @@
+# API Reference — SorobanLoyalty Backend
+
+Base URL: `http://localhost:3001` (local) or your deployed backend URL.
+
+All responses are JSON. All timestamps are Unix seconds (integer) unless noted.
+
+---
+
+## Authentication
+
+The backend API is **read-only** — it exposes indexed on-chain data. No authentication is required for any endpoint.
+
+Write operations (claim, redeem, create campaign) are submitted **directly to the Soroban RPC** from the frontend, signed by the user's Freighter wallet. The backend never handles private keys.
+
+---
+
+## Endpoints
+
+### Health
+
+#### `GET /health`
+
+Returns the operational status of the backend and its dependencies.
+
+**Request parameters:** none
+
+**Response `200 OK`**
+
+```json
+{
+  "status": "healthy",
+  "checks": {
+    "stellar": {
+      "reachable": true,
+      "latency": 42
+    },
+    "database": {
+      "connected": true,
+      "responseTime": 3
+    },
+    "indexer": {
+      "running": true
+    }
+  },
+  "timestamp": "2026-04-23T22:00:00.000Z",
+  "uptime": 3600.5
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `status` | `"healthy" \| "degraded" \| "unhealthy"` | Overall status. `healthy` = all checks pass; `degraded` = at least one passes; `unhealthy` = all fail. |
+| `checks.stellar.reachable` | `boolean` | Whether the Soroban RPC responded successfully. |
+| `checks.stellar.latency` | `number` | RPC round-trip time in milliseconds. |
+| `checks.database.connected` | `boolean` | Whether PostgreSQL responded to a ping. |
+| `checks.database.responseTime` | `number` | DB ping round-trip time in milliseconds. |
+| `checks.indexer.running` | `boolean` | Whether the event indexer is active. |
+| `timestamp` | `string` | ISO 8601 timestamp of the health check. |
+| `uptime` | `number` | Process uptime in seconds. |
+
+**Example**
+
+```bash
+curl http://localhost:3001/health
+```
+
+---
+
+### Campaigns
+
+#### `GET /campaigns`
+
+Returns a paginated list of all campaigns indexed from the blockchain.
+
+**Query parameters**
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `limit` | `integer` | No | `20` | Number of campaigns to return. Max `100`. |
+| `offset` | `integer` | No | `0` | Number of campaigns to skip (for pagination). |
+
+**Response `200 OK`**
+
+```json
+{
+  "campaigns": [
+    {
+      "id": 1,
+      "merchant": "GABC...XYZ",
+      "reward_amount": 100,
+      "expiration": 1745000000,
+      "active": true,
+      "total_claimed": 42,
+      "tx_hash": "abc123...",
+      "created_at": "2026-04-19T10:00:00.000Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `campaigns` | `Campaign[]` | Array of campaign objects (see schema below). |
+| `total` | `integer` | Total number of campaigns in the database (ignores pagination). |
+
+**Campaign object**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `integer` | Unique campaign ID (auto-incremented on-chain). |
+| `merchant` | `string` | Stellar public key of the campaign creator. |
+| `reward_amount` | `integer` | LYT tokens awarded per claim. |
+| `expiration` | `integer` | Unix timestamp after which the campaign is expired. |
+| `active` | `boolean` | Whether the merchant has activated the campaign. |
+| `total_claimed` | `integer` | Number of times the reward has been claimed. |
+| `tx_hash` | `string \| null` | Transaction hash of the creation event. |
+| `created_at` | `string` | ISO 8601 timestamp when the record was indexed. |
+
+**Error responses**
+
+| Status | Body | Condition |
+|---|---|---|
+| `500` | `{ "error": "Failed to fetch campaigns" }` | Database error. |
+
+**Example**
+
+```bash
+# First page
+curl "http://localhost:3001/campaigns?limit=20&offset=0"
+
+# Second page
+curl "http://localhost:3001/campaigns?limit=20&offset=20"
+```
+
+---
+
+#### `GET /campaigns/:id`
+
+Returns a single campaign by its on-chain ID.
+
+**Path parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `id` | `integer` | Yes | Campaign ID. |
+
+**Response `200 OK`**
+
+```json
+{
+  "campaign": {
+    "id": 1,
+    "merchant": "GABC...XYZ",
+    "reward_amount": 100,
+    "expiration": 1745000000,
+    "active": true,
+    "total_claimed": 42,
+    "tx_hash": "abc123...",
+    "created_at": "2026-04-19T10:00:00.000Z"
+  }
+}
+```
+
+**Error responses**
+
+| Status | Body | Condition |
+|---|---|---|
+| `400` | `{ "error": "Invalid id" }` | `id` is not a valid integer. |
+| `404` | `{ "error": "Not found" }` | No campaign with that ID exists. |
+| `500` | `{ "error": "Failed to fetch campaign" }` | Database error. |
+
+**Example**
+
+```bash
+curl http://localhost:3001/campaigns/1
+```
+
+---
+
+### Rewards
+
+#### `GET /user/:address/rewards`
+
+Returns all rewards claimed by a specific Stellar address.
+
+**Path parameters**
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `address` | `string` | Yes | 56-character Stellar public key (G…). |
+
+**Response `200 OK`**
+
+```json
+{
+  "rewards": [
+    {
+      "id": "uuid-here",
+      "user_address": "GABC...XYZ",
+      "campaign_id": 1,
+      "amount": 100,
+      "redeemed": false,
+      "redeemed_amount": 0,
+      "claimed_at": "2026-04-20T12:00:00.000Z",
+      "redeemed_at": null,
+      "campaign_reward": 100
+    }
+  ]
+}
+```
+
+**Reward object**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | UUID primary key. |
+| `user_address` | `string` | Stellar public key of the reward holder. |
+| `campaign_id` | `integer` | ID of the campaign this reward belongs to. |
+| `amount` | `integer` | LYT amount awarded. |
+| `redeemed` | `boolean` | Whether any portion has been redeemed (burned). |
+| `redeemed_amount` | `integer` | Total LYT burned by the user for this reward. |
+| `claimed_at` | `string` | ISO 8601 timestamp of the claim event. |
+| `redeemed_at` | `string \| null` | ISO 8601 timestamp of the most recent redeem, or `null`. |
+| `campaign_reward` | `integer` | The campaign's `reward_amount` at time of indexing (joined field). |
+
+**Error responses**
+
+| Status | Body | Condition |
+|---|---|---|
+| `400` | `{ "error": "Invalid Stellar address" }` | Address is missing or not 56 characters. |
+| `500` | `{ "error": "Failed to fetch rewards" }` | Database error. |
+
+**Example**
+
+```bash
+curl http://localhost:3001/user/GABC...XYZ/rewards
+```
+
+---
+
+## Error Format
+
+All error responses follow the same shape:
+
+```json
+{ "error": "<human-readable message>" }
+```
+
+---
+
+## Notes
+
+- **No write endpoints** — claim and redeem are on-chain operations submitted directly from the frontend to the Soroban RPC. The backend only indexes the resulting events.
+- **Eventual consistency** — after a transaction is submitted, the indexer may take a few seconds to process the event and reflect it in the API responses.
+- **Pagination** — use `limit` and `offset` on `GET /campaigns` for large datasets. The `total` field in the response lets you calculate the number of pages.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,171 @@
+# Frontend — SorobanLoyalty
+
+Next.js 14 (App Router) frontend for the SorobanLoyalty platform. Users claim and redeem LYT rewards; merchants create campaigns — all signed on-chain via the Freighter browser extension.
+
+---
+
+## Local Development Setup
+
+### Prerequisites
+
+- Node.js 20+
+- [Freighter browser extension](https://www.freighter.app/) installed
+- Backend API running (see root README)
+
+### Install & run
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+App is available at `http://localhost:3000`.
+
+---
+
+## Environment Variables
+
+Copy `.env.example` from the project root and set the following `NEXT_PUBLIC_*` variables:
+
+| Variable | Description | Default |
+|---|---|---|
+| `NEXT_PUBLIC_API_URL` | Backend REST API base URL | `http://localhost:3001` |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | Soroban RPC endpoint | `http://localhost:8000/soroban/rpc` |
+| `NEXT_PUBLIC_NETWORK_PASSPHRASE` | Stellar network passphrase | `Test SDF Network ; September 2015` |
+| `NEXT_PUBLIC_REWARDS_CONTRACT_ID` | Deployed rewards contract address | _(set after deploy)_ |
+| `NEXT_PUBLIC_CAMPAIGN_CONTRACT_ID` | Deployed campaign contract address | _(set after deploy)_ |
+
+> All variables are prefixed `NEXT_PUBLIC_` so they are inlined at build time and available in the browser.
+
+---
+
+## Component Architecture
+
+```
+src/
+├── app/                        # Next.js App Router pages
+│   ├── layout.tsx              # Root layout — WalletProvider, I18nProvider, nav
+│   ├── page.tsx                # Home / redirect
+│   ├── dashboard/page.tsx      # Claim rewards, view balance, infinite-scroll campaigns
+│   ├── merchant/page.tsx       # Create & manage campaigns
+│   ├── analytics/page.tsx      # Campaign performance stats
+│   └── transactions/           # Transaction history
+├── components/
+│   ├── WalletConnector.tsx     # Connect / disconnect Freighter button
+│   ├── CampaignCard.tsx        # Campaign display + claim action
+│   ├── RewardList.tsx          # User reward list + redeem action
+│   ├── NetworkBanner.tsx       # Degraded / unreachable network warning
+│   └── NetworkStatusIndicator.tsx  # Status dot in nav
+├── context/
+│   ├── WalletContext.tsx       # Freighter public key state, connect/disconnect
+│   └── I18nContext.tsx         # i18n locale state (en / es)
+├── hooks/
+│   └── useNetworkStatus.ts     # Polls /health, exposes { health }
+└── lib/
+    ├── freighter.ts            # Freighter API wrappers
+    ├── soroban.ts              # Contract invocation helpers
+    ├── api.ts                  # Backend REST client
+    └── export.ts               # CSV / JSON data export helpers
+```
+
+### Key data flows
+
+- **Claim reward**: `DashboardPage` → `claimReward()` (lib/soroban.ts) → Freighter signs → Soroban RPC submits → backend indexes event → UI refreshes via `api.getUserRewards()`.
+- **Create campaign**: `MerchantPage` → `createCampaign()` (lib/soroban.ts) → Freighter signs → Soroban RPC submits.
+- **Read data**: All read operations go through the backend REST API (`lib/api.ts`), not directly to the RPC.
+
+---
+
+## Freighter Integration
+
+Freighter is a Stellar browser extension wallet. The integration lives in `src/lib/freighter.ts` and `src/context/WalletContext.tsx`.
+
+### How wallet connection works
+
+1. On mount, `WalletContext` calls `getPublicKey()` — if Freighter already has an active session the key is restored silently.
+2. When the user clicks **Connect Wallet**, `connectWallet()` calls `freighter.getPublicKey()`, which prompts the extension if not already authorised.
+3. The returned 56-character Stellar public key is stored in React state and used for all subsequent contract calls and API queries.
+4. `disconnect()` clears the key from state (Freighter session itself is not revoked).
+
+### Signing transactions
+
+`lib/soroban.ts` builds a Soroban transaction, simulates it via the RPC, then calls `signTransaction(xdr, networkPassphrase)` which delegates to `freighter.signTransaction()`. The signed XDR is submitted back to the RPC.
+
+```ts
+// Example: claim a reward
+import { claimReward } from "@/lib/soroban";
+await claimReward(publicKey, campaignId);
+```
+
+> Freighter must be on the same network as `NEXT_PUBLIC_NETWORK_PASSPHRASE`. Switch networks inside the extension if needed.
+
+---
+
+## Testing
+
+### Unit / integration tests
+
+The project uses the Next.js built-in Jest setup. Run:
+
+```bash
+npm test
+```
+
+### E2E tests (Playwright)
+
+E2E tests live in `../e2e/` and cover wallet connection, campaign listing, and campaign detail flows.
+
+```bash
+# From the e2e directory
+cd ../e2e
+npm install
+npx playwright install
+npx playwright test
+```
+
+Tests run against a live local stack (frontend + backend + local Soroban node). Start the full stack first:
+
+```bash
+# From project root
+docker-compose up --build
+```
+
+---
+
+## Deployment
+
+### Vercel
+
+1. Import the repository into Vercel.
+2. Set **Root Directory** to `frontend`.
+3. Add all `NEXT_PUBLIC_*` environment variables in the Vercel dashboard.
+4. Deploy — Vercel detects Next.js automatically.
+
+### Docker
+
+A production image is included:
+
+```bash
+# Build
+docker build -t soroban-loyalty-frontend ./frontend
+
+# Run
+docker run -p 3000:3000 \
+  -e NEXT_PUBLIC_API_URL=https://api.example.com \
+  -e NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org \
+  -e NEXT_PUBLIC_NETWORK_PASSPHRASE="Test SDF Network ; September 2015" \
+  -e NEXT_PUBLIC_REWARDS_CONTRACT_ID=<contract_id> \
+  -e NEXT_PUBLIC_CAMPAIGN_CONTRACT_ID=<contract_id> \
+  soroban-loyalty-frontend
+```
+
+Or use the root `docker-compose.yml` which wires all services together:
+
+```bash
+docker-compose up --build
+```
+
+### Build output
+
+The Next.js config uses `output: "standalone"` — the build artefact in `.next/standalone` is self-contained and can be deployed to any Node.js host.


### PR DESCRIPTION
  Closes #89                                                                                                                                              
  Closes #90                                                                                                                                              
  Closes #91                                                                                                                                              
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ## Summary                                                                                                                                              
                                                                                                                                                          
  This PR adds comprehensive documentation across three areas of the SorobanLoyalty platform that were previously undocumented or only briefly covered in 
  the root README.                                                                                                                                        
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                          
  ### `frontend/README.md` — Closes #89                                                                                                                   
                                                                                                                                                          
  A dedicated README for the Next.js 14 frontend service covering:                                                                                        
                                                                                                                                                          
  - **Local development setup** — prerequisites (Node.js 20+, Freighter extension), install steps, and dev server instructions                            
  - **Environment variables** — all `NEXT_PUBLIC_*` variables documented with descriptions and default values                                             
  - **Component architecture** — full `src/` directory tree with descriptions of every page, component, context, hook, and lib module; includes key data  
  flow descriptions for claim, redeem, and campaign creation                                                                                              
  - **Freighter integration** — explains the wallet connection lifecycle (silent restore on mount, user-triggered connect, disconnect), how transactions  
  are built/simulated/signed via `lib/soroban.ts`, and a code example                                                                                     
  - **Testing instructions** — unit test command (`npm test`) and full E2E Playwright setup (`cd ../e2e && npx playwright test`) with prerequisite stack  
  startup instructions                                                                                                                                    
  - **Deployment** — step-by-step instructions for Vercel (root directory, env vars) and Docker (standalone image build + run command with all env flags),
  plus a note on the `output: "standalone"` build artefact                                                                                                
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ### `contracts/README.md` — Closes #90                                                                                                                  
                                                                                                                                                          
  Smart contract architecture documentation covering all three Soroban contracts:                                                                         
                                                                                                                                                          
  - **Per-contract documentation** — purpose, full function table (name, auth requirement, description), storage layout table (key, storage type, value   
  type, description), and emitted events for `token`, `campaign`, and `rewards`                                                                           
  - **`Campaign` struct** — field-level documentation of the on-chain data structure                                                                      
  - **Cross-contract interaction diagram** — ASCII diagram showing the full call graph: `claim_reward` → `CampaignContract.is_active` →                   
  `CampaignContract.get_campaign` → `CampaignContract.record_claim` → `TokenContract.mint`; and `redeem_reward` → `TokenContract.burn`                    
  - **Authorization model** — table mapping every sensitive action to who is permitted to call it (token admin, merchant, claiming user, etc.)            
  - **Security assumptions and invariants** — documents the double-claim reentrancy guard (state written before external mint), overflow-safe arithmetic  
  (`checked_add` + release overflow checks), mint authority enforcement, ledger-time expiration, and one-time initialization guard                        
  - **Known limitations and edge cases** — unauthenticated `record_claim`, immutable campaign fields post-creation, single-step admin transfer, no        
  on-chain campaign enumeration, and non-SEP-41 token interface                                                                                           
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ### `docs/api-reference.md` — Closes #91                                                                                                                
                                                                                                                                                          
  Full API reference for the Express backend covering all four endpoints:                                                                                 
                                                                                                                                                          
  - **`GET /health`** — response schema with all fields (`status`, `checks.stellar`, `checks.database`, `checks.indexer`, `timestamp`, `uptime`), status  
  enum values explained, curl example                                                                                                                     
  - **`GET /campaigns`** — query parameters (`limit`, `offset`) with types/defaults/constraints, full `Campaign` response schema with field-level         
  descriptions, error codes, curl examples for first and second page                                                                                      
  - **`GET /campaigns/:id`** — path parameter, full response schema, all error codes (`400` invalid id, `404` not found, `500`), curl example             
  - **`GET /user/:address/rewards`** — path parameter validation (56-char Stellar key), full `Reward` response schema including joined `campaign_reward`  
  field, all error codes, curl example                                                                                                                    
  - **Authentication** — clearly states no auth is required; explains that write operations (claim, redeem, create campaign) bypass the backend entirely  
  and go direct to the Soroban RPC signed by Freighter                                                                                                    
  - **Error format** — documents the standard `{ "error": "<message>" }` shape used across all endpoints                                                  
  - **Notes** — eventual consistency caveat (indexer lag), pagination guidance using the `total` field      