### PR TITLE
ci: add cargo audit, npm audit, and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: npm
+    directory: "/backend"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: npm
+    directory: "/frontend"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - security
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -65,3 +65,120 @@ jobs:
           name: test-coverage
           path: backend/coverage/
           retention-days: 7
+
+  audit-backend:
+    name: Backend Security Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        id: npm_audit
+        # --audit-level=critical blocks on critical; we capture output for the comment
+        run: npm audit --audit-level=critical 2>&1 | tee audit-results.txt
+        continue-on-error: true
+
+      - name: Post audit results as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('backend/audit-results.txt', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## 🔒 Backend npm Audit Results\n\`\`\`\n${body}\n\`\`\``,
+            });
+
+      - name: Open issue for high vulnerabilities
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('backend/audit-results.txt', 'utf8');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '⚠️ High/Critical npm vulnerability detected (backend)',
+              labels: ['security', 'dependencies'],
+              body: `npm audit found vulnerabilities in the backend.\n\n\`\`\`\n${body}\n\`\`\``,
+            });
+
+      - name: Fail on critical vulnerabilities
+        if: steps.npm_audit.outcome == 'failure'
+        run: exit 1
+
+  audit-frontend:
+    name: Frontend Security Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        id: npm_audit
+        run: npm audit --audit-level=critical 2>&1 | tee audit-results.txt
+        continue-on-error: true
+
+      - name: Post audit results as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('frontend/audit-results.txt', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## 🔒 Frontend npm Audit Results\n\`\`\`\n${body}\n\`\`\``,
+            });
+
+      - name: Open issue for high vulnerabilities
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('frontend/audit-results.txt', 'utf8');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '⚠️ High/Critical npm vulnerability detected (frontend)',
+              labels: ['security', 'dependencies'],
+              body: `npm audit found vulnerabilities in the frontend.\n\n\`\`\`\n${body}\n\`\`\``,
+            });
+
+      - name: Fail on critical vulnerabilities
+        if: steps.npm_audit.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -53,3 +53,53 @@ jobs:
 
       - name: Build contracts (wasm32)
         run: cargo build --target wasm32-unknown-unknown --release --workspace
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Run cargo audit
+        id: cargo_audit
+        # --deny unsound --deny yanked treats those as errors; critical vulns always error
+        run: cargo audit --deny warnings 2>&1 | tee audit-results.txt
+        continue-on-error: true
+
+      - name: Post audit results as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('audit-results.txt', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `## 🔒 Cargo Audit Results\n\`\`\`\n${body}\n\`\`\``,
+            });
+
+      - name: Open issue for high vulnerabilities
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('audit-results.txt', 'utf8');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: '⚠️ High/Critical Cargo vulnerability detected',
+              labels: ['security', 'dependencies'],
+              body: `Cargo audit found vulnerabilities in the latest CI run.\n\n\`\`\`\n${body}\n\`\`\``,
+            });
+
+      - name: Fail on critical vulnerabilities
+        if: steps.cargo_audit.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
- rust-ci.yml: add 'audit' job running cargo audit --deny warnings; posts results as PR comment; opens GitHub issue on high/critical; blocks merge on failure
- backend-ci.yml: add 'audit-backend' and 'audit-frontend' jobs running npm audit --audit-level=critical; same PR comment + issue creation pattern
- .github/dependabot.yml: weekly automated PRs for Cargo, backend npm, frontend npm, and GitHub Actions dependencies

Closes #77 