### PR TITLE
feat(campaign): add on-chain name/description metadata

### DIFF
--- a/contracts/campaign/src/lib.rs
+++ b/contracts/campaign/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol,
+    contract, contractimpl, contracttype, symbol_short, Address, Bytes, Env, Symbol,
 };
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -15,6 +15,10 @@ pub struct Campaign {
     pub expiration: u64, // Unix timestamp (seconds)
     pub active: bool,
     pub total_claimed: u64,
+    /// Campaign name — max 64 bytes UTF-8
+    pub name: Bytes,
+    /// Campaign description — max 256 bytes UTF-8
+    pub description: Bytes,
 }
 
 #[contracttype]
@@ -64,11 +68,14 @@ impl CampaignContract {
     // ── Public interface ──────────────────────────────────────────────────────
 
     /// Create a new campaign. Only the merchant (caller) can create it.
+    /// `name` max 64 bytes, `description` max 256 bytes.
     pub fn create_campaign(
         env: Env,
         merchant: Address,
         reward_amount: i128,
         expiration: u64,
+        name: Bytes,
+        description: Bytes,
     ) -> u64 {
         merchant.require_auth();
         assert!(reward_amount > 0, "reward_amount must be positive");
@@ -76,6 +83,8 @@ impl CampaignContract {
             expiration > env.ledger().timestamp(),
             "expiration must be in the future"
         );
+        assert!(name.len() <= 64, "name exceeds 64 bytes");
+        assert!(description.len() <= 256, "description exceeds 256 bytes");
 
         let id = Self::bump_id(&env);
         let campaign = Campaign {
@@ -85,13 +94,17 @@ impl CampaignContract {
             expiration,
             active: true,
             total_claimed: 0,
+            name: name.clone(),
+            description: description.clone(),
         };
         env.storage()
             .persistent()
             .set(&DataKey::Campaign(id), &campaign);
 
-        env.events()
-            .publish((CAMPAIGN_CREATED, symbol_short!("id"), id), merchant);
+        env.events().publish(
+            (CAMPAIGN_CREATED, symbol_short!("id"), id),
+            (merchant, name, description),
+        );
 
         id
     }
@@ -125,6 +138,12 @@ impl CampaignContract {
         Self::get_campaign_internal(&env, campaign_id)
     }
 
+    /// View function returning only the on-chain metadata fields.
+    pub fn get_campaign_metadata(env: Env, campaign_id: u64) -> (Bytes, Bytes) {
+        let c = Self::get_campaign_internal(&env, campaign_id);
+        (c.name, c.description)
+    }
+
     fn get_campaign_internal(env: &Env, campaign_id: u64) -> Campaign {
         env.storage()
             .persistent()
@@ -143,7 +162,10 @@ impl CampaignContract {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::{Address as _, Ledger}, Env};
+    use soroban_sdk::{
+        testutils::{Address as _, Ledger},
+        Bytes, Env,
+    };
 
     fn setup() -> (Env, Address, CampaignContractClient<'static>) {
         let env = Env::default();
@@ -155,17 +177,58 @@ mod tests {
         (env, admin, client)
     }
 
+    fn name(env: &Env) -> Bytes {
+        Bytes::from_slice(env, b"Summer Sale")
+    }
+
+    fn desc(env: &Env) -> Bytes {
+        Bytes::from_slice(env, b"Earn LYT on every purchase this summer")
+    }
+
     #[test]
     fn test_create_campaign() {
         let (env, _admin, client) = setup();
         let merchant = Address::generate(&env);
         let expiry = env.ledger().timestamp() + 86400;
-        let id = client.create_campaign(&merchant, &100, &expiry);
+        let id = client.create_campaign(&merchant, &100, &expiry, &name(&env), &desc(&env));
         assert_eq!(id, 1);
         let c = client.get_campaign(&id);
         assert_eq!(c.merchant, merchant);
         assert_eq!(c.reward_amount, 100);
         assert!(c.active);
+        assert_eq!(c.name, name(&env));
+        assert_eq!(c.description, desc(&env));
+    }
+
+    #[test]
+    fn test_get_campaign_metadata() {
+        let (env, _admin, client) = setup();
+        let merchant = Address::generate(&env);
+        let expiry = env.ledger().timestamp() + 86400;
+        let id = client.create_campaign(&merchant, &100, &expiry, &name(&env), &desc(&env));
+        let (n, d) = client.get_campaign_metadata(&id);
+        assert_eq!(n, name(&env));
+        assert_eq!(d, desc(&env));
+    }
+
+    #[test]
+    #[should_panic(expected = "name exceeds 64 bytes")]
+    fn test_name_too_long() {
+        let (env, _admin, client) = setup();
+        let merchant = Address::generate(&env);
+        let expiry = env.ledger().timestamp() + 86400;
+        let long_name = Bytes::from_slice(env, &[b'x'; 65]);
+        client.create_campaign(&merchant, &100, &expiry, &long_name, &desc(&env));
+    }
+
+    #[test]
+    #[should_panic(expected = "description exceeds 256 bytes")]
+    fn test_description_too_long() {
+        let (env, _admin, client) = setup();
+        let merchant = Address::generate(&env);
+        let expiry = env.ledger().timestamp() + 86400;
+        let long_desc = Bytes::from_slice(env, &[b'd'; 257]);
+        client.create_campaign(&merchant, &100, &expiry, &name(&env), &long_desc);
     }
 
     #[test]
@@ -173,8 +236,7 @@ mod tests {
     fn test_expired_campaign_rejected() {
         let (env, _admin, client) = setup();
         let merchant = Address::generate(&env);
-        // expiration in the past
-        client.create_campaign(&merchant, &100, &0);
+        client.create_campaign(&merchant, &100, &0, &name(&env), &desc(&env));
     }
 
     #[test]
@@ -182,7 +244,7 @@ mod tests {
         let (env, _admin, client) = setup();
         let merchant = Address::generate(&env);
         let expiry = env.ledger().timestamp() + 86400;
-        let id = client.create_campaign(&merchant, &100, &expiry);
+        let id = client.create_campaign(&merchant, &100, &expiry, &name(&env), &desc(&env));
         client.set_active(&id, &false);
         assert!(!client.get_campaign(&id).active);
     }
@@ -192,10 +254,9 @@ mod tests {
         let (env, _admin, client) = setup();
         let merchant = Address::generate(&env);
         let expiry = env.ledger().timestamp() + 10;
-        let id = client.create_campaign(&merchant, &100, &expiry);
+        let id = client.create_campaign(&merchant, &100, &expiry, &name(&env), &desc(&env));
         assert!(client.is_active(&id));
 
-        // advance ledger past expiry
         env.ledger().with_mut(|l| l.timestamp = expiry + 1);
         assert!(!client.is_active(&id));
     }

--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -202,14 +202,20 @@ mod tests {
         TestSetup { env, token, campaign, rewards }
     }
 
+    fn make_campaign(t: &TestSetup, merchant: &Address, reward: i128) -> u64 {
+        let expiry = t.env.ledger().timestamp() + 86400;
+        let name = soroban_sdk::Bytes::from_slice(&t.env, b"Test Campaign");
+        let desc = soroban_sdk::Bytes::from_slice(&t.env, b"Test description");
+        t.campaign.create_campaign(merchant, &reward, &expiry, &name, &desc)
+    }
+
     #[test]
     fn test_claim_mints_tokens() {
         let t = setup();
         let merchant = Address::generate(&t.env);
         let user = Address::generate(&t.env);
-        let expiry = t.env.ledger().timestamp() + 86400;
 
-        let cid = t.campaign.create_campaign(&merchant, &500, &expiry);
+        let cid = make_campaign(&t, &merchant, 500);
         t.rewards.claim_reward(&user, &cid);
 
         assert_eq!(t.token.balance(&user), 500);
@@ -222,9 +228,8 @@ mod tests {
         let t = setup();
         let merchant = Address::generate(&t.env);
         let user = Address::generate(&t.env);
-        let expiry = t.env.ledger().timestamp() + 86400;
 
-        let cid = t.campaign.create_campaign(&merchant, &500, &expiry);
+        let cid = make_campaign(&t, &merchant, 500);
         t.rewards.claim_reward(&user, &cid);
         t.rewards.claim_reward(&user, &cid);
     }
@@ -235,9 +240,8 @@ mod tests {
         let t = setup();
         let merchant = Address::generate(&t.env);
         let user = Address::generate(&t.env);
-        let expiry = t.env.ledger().timestamp() + 86400;
 
-        let cid = t.campaign.create_campaign(&merchant, &500, &expiry);
+        let cid = make_campaign(&t, &merchant, 500);
         t.campaign.set_active(&cid, &false);
         t.rewards.claim_reward(&user, &cid);
     }
@@ -249,8 +253,9 @@ mod tests {
         let merchant = Address::generate(&t.env);
         let user = Address::generate(&t.env);
         let expiry = t.env.ledger().timestamp() + 10;
-
-        let cid = t.campaign.create_campaign(&merchant, &500, &expiry);
+        let name = soroban_sdk::Bytes::from_slice(&t.env, b"Test Campaign");
+        let desc = soroban_sdk::Bytes::from_slice(&t.env, b"Test description");
+        let cid = t.campaign.create_campaign(&merchant, &500, &expiry, &name, &desc);
         t.env.ledger().with_mut(|l| l.timestamp = expiry + 1);
         t.rewards.claim_reward(&user, &cid);
     }
@@ -260,9 +265,8 @@ mod tests {
         let t = setup();
         let merchant = Address::generate(&t.env);
         let user = Address::generate(&t.env);
-        let expiry = t.env.ledger().timestamp() + 86400;
 
-        let cid = t.campaign.create_campaign(&merchant, &500, &expiry);
+        let cid = make_campaign(&t, &merchant, 500);
         t.rewards.claim_reward(&user, &cid);
         t.rewards.redeem_reward(&user, &200);
 
@@ -276,9 +280,8 @@ mod tests {
         let merchant = Address::generate(&t.env);
         let user1 = Address::generate(&t.env);
         let user2 = Address::generate(&t.env);
-        let expiry = t.env.ledger().timestamp() + 86400;
 
-        let cid = t.campaign.create_campaign(&merchant, &100, &expiry);
+        let cid = make_campaign(&t, &merchant, 100);
         t.rewards.claim_reward(&user1, &cid);
         t.rewards.claim_reward(&user2, &cid);
 


### PR DESCRIPTION
- Add name (max 64 bytes) and description (max 256 bytes) fields to Campaign struct
- Enforce byte limits in create_campaign with assertions
- Add get_campaign_metadata view function returning (name, description)
- Include name and description in CAM_CRT event payload
- Update rewards contract tests to pass metadata args
- Storage cost: ~320 bytes extra per campaign (~0.008 XLM/30-day campaign)

Closes #121 