### PR TITLE
feat(env): validate all env vars at startup with Zod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,46 +1,70 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Environment variables for Soroban Loyalty Platform
+#
+# Copy this file to .env and fill in the values.
+# Variables marked REQUIRED must be set before the app will start.
+# Variables marked OPTIONAL fall back to the shown default when omitted.
+#
+# In production, required secrets are loaded from AWS Secrets Manager
+# (see SECRETS_ARN below). The rest are injected via K8s ConfigMap / ECS
+# task definition.
+# ─────────────────────────────────────────────────────────────────────────────
+
 # ── Soroban RPC ───────────────────────────────────────────────────────────────
+# REQUIRED — Soroban JSON-RPC endpoint
 SOROBAN_RPC_URL=http://localhost:8000/soroban/rpc
 
-# ── Network ───────────────────────────────────────────────────────────────────
+# REQUIRED — Stellar network passphrase
 # Local:    "Standalone Network ; February 2017"
 # Testnet:  "Test SDF Network ; September 2015"
 # Mainnet:  "Public Global Stellar Network ; September 2015"
 NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 
 # ── Database ──────────────────────────────────────────────────────────────────
+# REQUIRED (unless DB_SECRET_ARN is set and secrets.ts populates it at runtime)
 DATABASE_URL=postgres://loyalty:loyalty_secret@localhost:5432/soroban_loyalty
 
-# ── AWS Secrets Manager (optional — overrides DATABASE_URL when set) ──────────
-# ARN or name of the secret containing DB credentials (JSON: username/password/host/port/dbname)
-DB_SECRET_ARN=
+# ── AWS Secrets Manager ───────────────────────────────────────────────────────
+# OPTIONAL — ARN or name of the JSON secret containing DB credentials and
+#            contract IDs. When set, secrets.ts loads values into process.env
+#            before env validation runs.
+SECRETS_ARN=
+
+# OPTIONAL — AWS region for Secrets Manager. Default: us-east-1
 AWS_REGION=us-east-1
 
-# ── Deployed contract IDs (fill after deploying) ─────────────────────────────
-TOKEN_CONTRACT_ID=
-CAMPAIGN_CONTRACT_ID=
+# ── Deployed contract IDs ─────────────────────────────────────────────────────
+# REQUIRED — fill in after deploying contracts
 REWARDS_CONTRACT_ID=
+CAMPAIGN_CONTRACT_ID=
+TOKEN_CONTRACT_ID=
 
-# ── Backend ───────────────────────────────────────────────────────────────────
+# ── Backend server ────────────────────────────────────────────────────────────
+# OPTIONAL — HTTP port. Default: 3001
 PORT=3001
+
+# OPTIONAL — Set to "false" to disable the on-chain event indexer. Default: true
 ENABLE_INDEXER=true
 
-# ── Alerting (issue #82) ──────────────────────────────────────────────────────
-# Slack Incoming Webhook URL for #alerts channel
+# ── Alerting ──────────────────────────────────────────────────────────────────
+# OPTIONAL — Slack Incoming Webhook URL for #alerts channel
 SLACK_WEBHOOK_URL=
-# Set to "true" to suppress alerts during maintenance windows
+
+# OPTIONAL — Set to "true" to suppress alerts during maintenance windows. Default: false
 MAINTENANCE_MODE=false
 
-# ── Monitoring (issue #73) ────────────────────────────────────────────────────
-# Grafana admin password (default: admin — change in production)
+# ── Monitoring ────────────────────────────────────────────────────────────────
+# OPTIONAL — Grafana admin password. Default: admin (change in production)
 GRAFANA_ADMIN_PASSWORD=admin
 
-# ── SSL / TLS (issue #84) ─────────────────────────────────────────────────────
-# Domain for Let's Encrypt certificate (apex + wildcard)
+# ── SSL / TLS ─────────────────────────────────────────────────────────────────
+# OPTIONAL — Domain for Let's Encrypt certificate
 DOMAIN=soroban-loyalty.example.com
-# Email for ACME account registration and expiry notices
+
+# OPTIONAL — Email for ACME account registration and expiry notices
 ACME_EMAIL=ops@example.com
 
-# ── Frontend (prefix NEXT_PUBLIC_) ───────────────────────────────────────────
+# ── Frontend (Next.js public vars) ───────────────────────────────────────────
 NEXT_PUBLIC_API_URL=http://localhost:3001
 NEXT_PUBLIC_SOROBAN_RPC_URL=http://localhost:8000/soroban/rpc
 NEXT_PUBLIC_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"

--- a/backend/src/__tests__/env.test.ts
+++ b/backend/src/__tests__/env.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Tests for env.ts — environment variable validation.
+ *
+ * We test parseEnv() directly so we never trigger process.exit(1)
+ * or rely on the real process.env.
+ */
+
+import { parseEnv } from "../env";
+
+// ── Minimal valid env ─────────────────────────────────────────────────────────
+
+const VALID_ENV = {
+  SOROBAN_RPC_URL: "http://localhost:8000/soroban/rpc",
+  NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+  DATABASE_URL: "postgres://user:pass@localhost:5432/db",
+  REWARDS_CONTRACT_ID: "CREWARDS123",
+  CAMPAIGN_CONTRACT_ID: "CCAMPAIGN123",
+  TOKEN_CONTRACT_ID: "CTOKEN123",
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function valid(overrides: Record<string, string | undefined> = {}) {
+  return { ...VALID_ENV, ...overrides };
+}
+
+// ── Required fields ───────────────────────────────────────────────────────────
+
+describe("required fields", () => {
+  const requiredKeys: (keyof typeof VALID_ENV)[] = [
+    "SOROBAN_RPC_URL",
+    "NETWORK_PASSPHRASE",
+    "REWARDS_CONTRACT_ID",
+    "CAMPAIGN_CONTRACT_ID",
+    "TOKEN_CONTRACT_ID",
+  ];
+
+  test.each(requiredKeys)("throws when %s is missing", (key) => {
+    const env = valid({ [key]: undefined });
+    expect(() => parseEnv(env)).toThrow(/Environment validation failed/);
+  });
+
+  test.each(requiredKeys)("error message names the missing field %s", (key) => {
+    const env = valid({ [key]: undefined });
+    expect(() => parseEnv(env)).toThrow(key);
+  });
+
+  it("throws listing ALL missing required fields at once", () => {
+    expect(() =>
+      parseEnv({
+        // completely empty — all required fields absent
+      })
+    ).toThrow(/SOROBAN_RPC_URL/);
+  });
+});
+
+// ── SOROBAN_RPC_URL ───────────────────────────────────────────────────────────
+
+describe("SOROBAN_RPC_URL", () => {
+  it("accepts a valid http URL", () => {
+    const result = parseEnv(valid());
+    expect(result.SOROBAN_RPC_URL).toBe("http://localhost:8000/soroban/rpc");
+  });
+
+  it("accepts a valid https URL", () => {
+    const result = parseEnv(valid({ SOROBAN_RPC_URL: "https://rpc.example.com/soroban/rpc" }));
+    expect(result.SOROBAN_RPC_URL).toBe("https://rpc.example.com/soroban/rpc");
+  });
+
+  it("rejects a non-URL string", () => {
+    expect(() => parseEnv(valid({ SOROBAN_RPC_URL: "not-a-url" }))).toThrow(
+      /SOROBAN_RPC_URL/
+    );
+  });
+});
+
+// ── NETWORK_PASSPHRASE ────────────────────────────────────────────────────────
+
+describe("NETWORK_PASSPHRASE", () => {
+  it("accepts any non-empty string", () => {
+    const result = parseEnv(valid({ NETWORK_PASSPHRASE: "Public Global Stellar Network ; September 2015" }));
+    expect(result.NETWORK_PASSPHRASE).toBe("Public Global Stellar Network ; September 2015");
+  });
+
+  it("rejects an empty string", () => {
+    expect(() => parseEnv(valid({ NETWORK_PASSPHRASE: "" }))).toThrow(/NETWORK_PASSPHRASE/);
+  });
+});
+
+// ── DATABASE_URL ──────────────────────────────────────────────────────────────
+
+describe("DATABASE_URL", () => {
+  it("is optional — omitting it does not throw", () => {
+    const env = valid({ DATABASE_URL: undefined });
+    expect(() => parseEnv(env)).not.toThrow();
+  });
+
+  it("accepts a valid postgres URL", () => {
+    const result = parseEnv(valid());
+    expect(result.DATABASE_URL).toBe("postgres://user:pass@localhost:5432/db");
+  });
+
+  it("rejects a malformed URL", () => {
+    expect(() => parseEnv(valid({ DATABASE_URL: "not-a-url" }))).toThrow(/DATABASE_URL/);
+  });
+});
+
+// ── AWS_REGION ────────────────────────────────────────────────────────────────
+
+describe("AWS_REGION", () => {
+  it("defaults to us-east-1 when not set", () => {
+    const result = parseEnv(valid({ AWS_REGION: undefined }));
+    expect(result.AWS_REGION).toBe("us-east-1");
+  });
+
+  it("accepts a custom region", () => {
+    const result = parseEnv(valid({ AWS_REGION: "eu-west-1" }));
+    expect(result.AWS_REGION).toBe("eu-west-1");
+  });
+});
+
+// ── SECRETS_ARN ───────────────────────────────────────────────────────────────
+
+describe("SECRETS_ARN", () => {
+  it("is optional — omitting it does not throw", () => {
+    expect(() => parseEnv(valid({ SECRETS_ARN: undefined }))).not.toThrow();
+  });
+
+  it("accepts an ARN string", () => {
+    const arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret";
+    const result = parseEnv(valid({ SECRETS_ARN: arn }));
+    expect(result.SECRETS_ARN).toBe(arn);
+  });
+});
+
+// ── Contract IDs ──────────────────────────────────────────────────────────────
+
+describe("contract IDs", () => {
+  it("accepts all three contract IDs", () => {
+    const result = parseEnv(valid());
+    expect(result.REWARDS_CONTRACT_ID).toBe("CREWARDS123");
+    expect(result.CAMPAIGN_CONTRACT_ID).toBe("CCAMPAIGN123");
+    expect(result.TOKEN_CONTRACT_ID).toBe("CTOKEN123");
+  });
+
+  it("rejects empty REWARDS_CONTRACT_ID", () => {
+    expect(() => parseEnv(valid({ REWARDS_CONTRACT_ID: "" }))).toThrow(/REWARDS_CONTRACT_ID/);
+  });
+
+  it("rejects empty CAMPAIGN_CONTRACT_ID", () => {
+    expect(() => parseEnv(valid({ CAMPAIGN_CONTRACT_ID: "" }))).toThrow(/CAMPAIGN_CONTRACT_ID/);
+  });
+
+  it("rejects empty TOKEN_CONTRACT_ID", () => {
+    expect(() => parseEnv(valid({ TOKEN_CONTRACT_ID: "" }))).toThrow(/TOKEN_CONTRACT_ID/);
+  });
+});
+
+// ── PORT ──────────────────────────────────────────────────────────────────────
+
+describe("PORT", () => {
+  it("defaults to 3001 when not set", () => {
+    const result = parseEnv(valid({ PORT: undefined }));
+    expect(result.PORT).toBe(3001);
+  });
+
+  it("coerces a valid port string to a number", () => {
+    const result = parseEnv(valid({ PORT: "8080" }));
+    expect(result.PORT).toBe(8080);
+  });
+
+  it("rejects port 0", () => {
+    expect(() => parseEnv(valid({ PORT: "0" }))).toThrow(/PORT/);
+  });
+
+  it("rejects port above 65535", () => {
+    expect(() => parseEnv(valid({ PORT: "99999" }))).toThrow(/PORT/);
+  });
+
+  it("rejects a non-numeric port", () => {
+    expect(() => parseEnv(valid({ PORT: "abc" }))).toThrow(/PORT/);
+  });
+});
+
+// ── ENABLE_INDEXER ────────────────────────────────────────────────────────────
+
+describe("ENABLE_INDEXER", () => {
+  it("defaults to true when not set", () => {
+    const result = parseEnv(valid({ ENABLE_INDEXER: undefined }));
+    expect(result.ENABLE_INDEXER).toBe(true);
+  });
+
+  it('parses "true" as boolean true', () => {
+    const result = parseEnv(valid({ ENABLE_INDEXER: "true" }));
+    expect(result.ENABLE_INDEXER).toBe(true);
+  });
+
+  it('parses "false" as boolean false', () => {
+    const result = parseEnv(valid({ ENABLE_INDEXER: "false" }));
+    expect(result.ENABLE_INDEXER).toBe(false);
+  });
+
+  it("rejects an invalid value", () => {
+    expect(() => parseEnv(valid({ ENABLE_INDEXER: "yes" }))).toThrow(/ENABLE_INDEXER/);
+  });
+});
+
+// ── SLACK_WEBHOOK_URL ─────────────────────────────────────────────────────────
+
+describe("SLACK_WEBHOOK_URL", () => {
+  it("is optional — omitting it does not throw", () => {
+    expect(() => parseEnv(valid({ SLACK_WEBHOOK_URL: undefined }))).not.toThrow();
+  });
+
+  it("accepts a valid https URL", () => {
+    const url = "https://hooks.slack.com/services/T00/B00/xxx";
+    const result = parseEnv(valid({ SLACK_WEBHOOK_URL: url }));
+    expect(result.SLACK_WEBHOOK_URL).toBe(url);
+  });
+
+  it("rejects a non-URL string", () => {
+    expect(() => parseEnv(valid({ SLACK_WEBHOOK_URL: "not-a-url" }))).toThrow(
+      /SLACK_WEBHOOK_URL/
+    );
+  });
+});
+
+// ── MAINTENANCE_MODE ──────────────────────────────────────────────────────────
+
+describe("MAINTENANCE_MODE", () => {
+  it("defaults to false when not set", () => {
+    const result = parseEnv(valid({ MAINTENANCE_MODE: undefined }));
+    expect(result.MAINTENANCE_MODE).toBe(false);
+  });
+
+  it('parses "true" as boolean true', () => {
+    const result = parseEnv(valid({ MAINTENANCE_MODE: "true" }));
+    expect(result.MAINTENANCE_MODE).toBe(true);
+  });
+
+  it('parses "false" as boolean false', () => {
+    const result = parseEnv(valid({ MAINTENANCE_MODE: "false" }));
+    expect(result.MAINTENANCE_MODE).toBe(false);
+  });
+
+  it("rejects an invalid value", () => {
+    expect(() => parseEnv(valid({ MAINTENANCE_MODE: "1" }))).toThrow(/MAINTENANCE_MODE/);
+  });
+});
+
+// ── Happy path — full valid env ───────────────────────────────────────────────
+
+describe("full valid environment", () => {
+  it("parses a complete env without throwing", () => {
+    const result = parseEnv({
+      SOROBAN_RPC_URL: "https://soroban-testnet.stellar.org",
+      NETWORK_PASSPHRASE: "Test SDF Network ; September 2015",
+      DATABASE_URL: "postgres://loyalty:secret@db:5432/loyalty",
+      SECRETS_ARN: "arn:aws:secretsmanager:us-east-1:123:secret:prod",
+      AWS_REGION: "us-east-1",
+      REWARDS_CONTRACT_ID: "CREWARDS",
+      CAMPAIGN_CONTRACT_ID: "CCAMPAIGN",
+      TOKEN_CONTRACT_ID: "CTOKEN",
+      PORT: "3001",
+      ENABLE_INDEXER: "true",
+      SLACK_WEBHOOK_URL: "https://hooks.slack.com/services/T/B/x",
+      MAINTENANCE_MODE: "false",
+    });
+
+    expect(result.PORT).toBe(3001);
+    expect(result.ENABLE_INDEXER).toBe(true);
+    expect(result.MAINTENANCE_MODE).toBe(false);
+    expect(result.AWS_REGION).toBe("us-east-1");
+  });
+});

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -17,8 +17,10 @@ interface DbSecret {
   dbname: string;
 }
 
+import { env } from "./env";
+
 const secretsClient = new SecretsManagerClient({
-  region: process.env.AWS_REGION ?? "us-east-1",
+  region: env.AWS_REGION,
 });
 
 pool.on("error", (err) => {

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,0 +1,125 @@
+/**
+ * env.ts — Validate and export all environment variables at startup.
+ *
+ * Uses Zod to parse process.env. If any required variable is missing or
+ * malformed the process exits immediately with a clear, human-readable
+ * error listing every problem — no cryptic runtime failures later.
+ *
+ * Import this module BEFORE any service initialisation (db, rpc, etc.).
+ * All other modules should import typed values from here instead of
+ * reading process.env directly.
+ *
+ * Required vars must be present in the environment (or loaded from
+ * AWS Secrets Manager via secrets.ts before this module is imported).
+ * Optional vars fall back to the documented defaults shown below.
+ */
+
+import { z } from "zod";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Accept "true" / "false" strings as booleans (env vars are always strings). */
+const booleanString = (defaultValue: boolean) =>
+  z
+    .enum(["true", "false"])
+    .default(defaultValue ? "true" : "false")
+    .transform((v) => v === "true");
+
+/** Coerce a string to a port number in the valid range. */
+const portString = (defaultValue: number) =>
+  z
+    .string()
+    .default(String(defaultValue))
+    .transform(Number)
+    .pipe(z.number().int().min(1).max(65535));
+
+// ── Schema ────────────────────────────────────────────────────────────────────
+
+const envSchema = z.object({
+  // ── Soroban RPC ─────────────────────────────────────────────────────────────
+  /** Soroban JSON-RPC endpoint. Required. */
+  SOROBAN_RPC_URL: z.string().url(),
+
+  /** Stellar network passphrase. Required. */
+  NETWORK_PASSPHRASE: z.string().min(1),
+
+  // ── Database ────────────────────────────────────────────────────────────────
+  /**
+   * Full Postgres connection string.
+   * Required unless DB_SECRET_ARN is set (secrets.ts will populate it).
+   * We make it optional here so local dev without Secrets Manager still works
+   * when DATABASE_URL is provided directly.
+   */
+  DATABASE_URL: z.string().url().optional(),
+
+  // ── AWS Secrets Manager ─────────────────────────────────────────────────────
+  /** ARN / name of the JSON secret in AWS Secrets Manager. Optional. */
+  SECRETS_ARN: z.string().optional(),
+
+  /** AWS region for Secrets Manager. Default: "us-east-1". */
+  AWS_REGION: z.string().default("us-east-1"),
+
+  // ── Contract IDs ────────────────────────────────────────────────────────────
+  /** Deployed Rewards contract ID. Required. */
+  REWARDS_CONTRACT_ID: z.string().min(1),
+
+  /** Deployed Campaign contract ID. Required. */
+  CAMPAIGN_CONTRACT_ID: z.string().min(1),
+
+  /** Deployed Token contract ID. Required. */
+  TOKEN_CONTRACT_ID: z.string().min(1),
+
+  // ── Server ──────────────────────────────────────────────────────────────────
+  /** HTTP port the Express server listens on. Default: 3001. */
+  PORT: portString(3001),
+
+  /** Set to "false" to disable the on-chain event indexer. Default: true. */
+  ENABLE_INDEXER: booleanString(true),
+
+  // ── Alerting ────────────────────────────────────────────────────────────────
+  /** Slack Incoming Webhook URL for #alerts. Optional. */
+  SLACK_WEBHOOK_URL: z.string().url().optional(),
+
+  /** Suppress alerts during maintenance windows. Default: false. */
+  MAINTENANCE_MODE: booleanString(false),
+});
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+/**
+ * Parse and validate an env-like object against the schema.
+ * Returns the typed result or throws with a human-readable message listing
+ * every issue. Exported so tests can call it directly without side-effects.
+ */
+export function parseEnv(raw: NodeJS.ProcessEnv = process.env) {
+  const result = envSchema.safeParse(raw);
+
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => `  • ${i.path.join(".")}: ${i.message}`)
+      .join("\n");
+
+    throw new Error(
+      `\n[env] ❌ Environment validation failed — fix the following before starting:\n\n${issues}\n\n` +
+        `  See .env.example for documentation on each variable.\n`
+    );
+  }
+
+  return result.data;
+}
+
+function validateEnv() {
+  try {
+    return parseEnv(process.env);
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+}
+
+// Only run validation (and potentially exit) when NOT in a test environment.
+// Tests import parseEnv() directly and supply their own fixture data.
+const isTest = process.env.NODE_ENV === "test" || process.env.JEST_WORKER_ID !== undefined;
+
+export const env = isTest ? ({} as ReturnType<typeof parseEnv>) : validateEnv();
+export type Env = typeof env;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,11 +9,18 @@ import { startIndexer } from "./indexer/indexer";
 import { rpcServer } from "./soroban";
 import { pool } from "./db";
 import { registry, httpRequestsTotal, httpRequestDuration, dbPoolActive, dbPoolIdle, dbPoolWaiting } from "./metrics";
+import { logger, requestLogger, errorAlertMiddleware } from "./logger";
 
-// Load .env first (no-op in production where env vars are injected),
-// then fetch secrets from AWS Secrets Manager before any other init.
+// ── Startup sequence ──────────────────────────────────────────────────────────
+// 1. Load .env (no-op in production where vars are injected)
+// 2. Pull secrets from AWS Secrets Manager (populates process.env)
+// 3. Validate ALL env vars via Zod — exits with a clear error if anything is
+//    missing or malformed. Must happen before any service is initialised.
 dotenv.config();
 await loadSecrets();
+
+// Dynamic import so env validation runs after secrets are loaded into process.env
+const { env } = await import("./env");
 
 const app = express();
 app.use(cors());
@@ -34,7 +41,6 @@ app.use((req, res, next) => {
 
 // ── /metrics endpoint for Prometheus scraping ─────────────────────────────────
 app.get("/metrics", async (_req, res) => {
-  // Snapshot DB pool stats
   dbPoolActive.set(pool.totalCount - pool.idleCount);
   dbPoolIdle.set(pool.idleCount);
   dbPoolWaiting.set(pool.waitingCount);
@@ -44,65 +50,60 @@ app.get("/metrics", async (_req, res) => {
 });
 
 app.get("/health", async (_req, res) => {
-  const startTime = Date.now();
   const checks: any = {
     stellar: { reachable: false, latency: 0 },
     database: { connected: false, responseTime: 0 },
-    indexer: { running: true }
+    indexer: { running: true },
   };
 
-  // Check Stellar network
   try {
     const stellarStart = Date.now();
     await rpcServer.getHealth();
     checks.stellar.reachable = true;
     checks.stellar.latency = Date.now() - stellarStart;
-  } catch (err) {
+  } catch {
     checks.stellar.reachable = false;
   }
 
-  // Check database
   try {
     const dbStart = Date.now();
-    await pool.query('SELECT 1');
+    await pool.query("SELECT 1");
     checks.database.connected = true;
     checks.database.responseTime = Date.now() - dbStart;
-  } catch (err) {
+  } catch {
     checks.database.connected = false;
   }
 
   const allHealthy = checks.stellar.reachable && checks.database.connected;
-  const status = allHealthy ? 'healthy' : (checks.stellar.reachable || checks.database.connected) ? 'degraded' : 'unhealthy';
+  const status = allHealthy
+    ? "healthy"
+    : checks.stellar.reachable || checks.database.connected
+    ? "degraded"
+    : "unhealthy";
 
-  res.json({
-    status,
-    checks,
-    timestamp: new Date().toISOString(),
-    uptime: process.uptime()
-  });
+  res.json({ status, checks, timestamp: new Date().toISOString(), uptime: process.uptime() });
 });
 
 app.use("/campaigns", campaignRouter);
 app.use("/", rewardRouter);
 app.use("/analytics", analyticsRouter);
 
-// Global error handler — logs + alerts on unhandled errors
 app.use(errorAlertMiddleware);
 
-// Catch unhandled promise rejections and exceptions
 process.on("unhandledRejection", (reason) => {
-  logger.critical("Unhandled promise rejection", reason instanceof Error ? reason : new Error(String(reason)));
+  logger.critical(
+    "Unhandled promise rejection",
+    reason instanceof Error ? reason : new Error(String(reason))
+  );
 });
 process.on("uncaughtException", (err) => {
   logger.critical("Uncaught exception", err);
   process.exit(1);
 });
 
-const PORT = process.env.PORT ?? 3001;
-
-app.listen(PORT, async () => {
-  logger.info(`Server listening on port ${PORT}`);
-  if (process.env.ENABLE_INDEXER !== "false") {
+app.listen(env.PORT, async () => {
+  logger.info(`Server listening on port ${env.PORT}`);
+  if (env.ENABLE_INDEXER) {
     await startIndexer();
   }
 });

--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -9,9 +9,10 @@ import { upsertReward, recordTransaction } from "../services/reward.service";
 import { pool } from "../db";
 import { logger } from "../logger";
 import { indexerLagBlocks, indexerEventsTotal } from "../metrics";
+import { env } from "../env";
 
-const REWARDS_CONTRACT = process.env.REWARDS_CONTRACT_ID ?? "";
-const CAMPAIGN_CONTRACT = process.env.CAMPAIGN_CONTRACT_ID ?? "";
+const REWARDS_CONTRACT = env.REWARDS_CONTRACT_ID;
+const CAMPAIGN_CONTRACT = env.CAMPAIGN_CONTRACT_ID;
 const POLL_INTERVAL_MS = 5_000;
 
 // Persist cursor so we don't re-process events on restart
@@ -73,7 +74,7 @@ async function processEvent(event: SorobanRpc.Api.RawEventResponse): Promise<voi
       tx_hash: event.txHash,
     });
     await recordTransaction(event.txHash, "campaign_created", merchant, id, null, event.ledger);
-    console.log(`[indexer] CampaignCreated id=${id} merchant=${merchant}`);
+    logger.info(`[indexer] CampaignCreated id=${id} merchant=${merchant}`);
   }
 
   if (event.contractId === REWARDS_CONTRACT && eventName === "RWD_CLM") {
@@ -84,7 +85,7 @@ async function processEvent(event: SorobanRpc.Api.RawEventResponse): Promise<voi
     const amount = decodeI128(valueVec[1]);
     await upsertReward({ user_address: user, campaign_id: campaignId, amount, redeemed: false, redeemed_amount: 0 });
     await recordTransaction(event.txHash, "claim", user, campaignId, amount, event.ledger);
-    console.log(`[indexer] RewardClaimed user=${user} campaign=${campaignId} amount=${amount}`);
+    logger.info(`[indexer] RewardClaimed user=${user} campaign=${campaignId} amount=${amount}`);
   }
 
   if (event.contractId === REWARDS_CONTRACT && eventName === "RWD_RDM") {
@@ -92,7 +93,7 @@ async function processEvent(event: SorobanRpc.Api.RawEventResponse): Promise<voi
     const user = decodeAddress(topics[2]);
     const amount = decodeI128(xdr.ScVal.fromXDR(event.value, "base64"));
     await recordTransaction(event.txHash, "redeem", user, null, amount, event.ledger);
-    console.log(`[indexer] RewardRedeemed user=${user} amount=${amount}`);
+    logger.info(`[indexer] RewardRedeemed user=${user} amount=${amount}`);
   }
 }
 
@@ -105,7 +106,7 @@ async function processEvent(event: SorobanRpc.Api.RawEventResponse): Promise<voi
  */
 export async function startIndexer(): Promise<void> {
   await ensureIndexerTable();
-  console.log("[indexer] started");
+  logger.info("[indexer] started");
 
   const poll = async () => {
     try {

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,7 +1,5 @@
 import { Request } from "express";
-
-const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL;
-const MAINTENANCE_MODE = process.env.MAINTENANCE_MODE === "true";
+import { env } from "./env";
 
 export type AlertLevel = "critical" | "error" | "warn" | "info";
 
@@ -13,7 +11,7 @@ interface AlertPayload {
 }
 
 async function sendSlackAlert(payload: AlertPayload): Promise<void> {
-  if (!SLACK_WEBHOOK_URL || MAINTENANCE_MODE) return;
+  if (!env.SLACK_WEBHOOK_URL || env.MAINTENANCE_MODE) return;
   const { level, message, error, context } = payload;
   const emoji = level === "critical" ? "🚨" : "⚠️";
   const runbook = "https://github.com/Dev-Odun-oss/Soroban-Loyalty/wiki/Runbooks";
@@ -28,7 +26,7 @@ async function sendSlackAlert(payload: AlertPayload): Promise<void> {
     .join("\n");
 
   try {
-    await fetch(SLACK_WEBHOOK_URL, {
+    await fetch(env.SLACK_WEBHOOK_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ text }),

--- a/backend/src/soroban.ts
+++ b/backend/src/soroban.ts
@@ -1,10 +1,5 @@
-import { SorobanRpc, Networks } from "@stellar/stellar-sdk";
-import dotenv from "dotenv";
+import { SorobanRpc } from "@stellar/stellar-sdk";
+import { env } from "./env";
 
-dotenv.config();
-
-const RPC_URL = process.env.SOROBAN_RPC_URL ?? "http://localhost:8000/soroban/rpc";
-const NETWORK_PASSPHRASE = process.env.NETWORK_PASSPHRASE ?? Networks.TESTNET;
-
-export const rpcServer = new SorobanRpc.Server(RPC_URL, { allowHttp: true });
-export { NETWORK_PASSPHRASE };
+export const rpcServer = new SorobanRpc.Server(env.SOROBAN_RPC_URL, { allowHttp: true });
+export const NETWORK_PASSPHRASE = env.NETWORK_PASSPHRASE;


### PR DESCRIPTION
close #20 

## Summary

The app previously started silently with missing or malformed environment
variables, only failing at runtime when those vars were first accessed —
producing cryptic errors in production. This PR fixes that by validating
the entire environment at startup using Zod, failing fast with a clear,
human-readable error before any service is initialised.

---

## Changes

### `backend/src/env.ts` (new)
- Zod schema covering every environment variable used by the backend
- Required: `SOROBAN_RPC_URL`, `NETWORK_PASSPHRASE`, `REWARDS_CONTRACT_ID`,
  `CAMPAIGN_CONTRACT_ID`, `TOKEN_CONTRACT_ID`
- Optional with documented defaults: `PORT` (3001), `ENABLE_INDEXER` (true),
  `MAINTENANCE_MODE` (false), `AWS_REGION` (us-east-1), `DATABASE_URL`,
  `SECRETS_ARN`, `SLACK_WEBHOOK_URL`
- Exports typed `env` object — single source of truth for all config
- Exports `parseEnv(raw?)` for testability (no `process.exit` side-effects)
- On failure: prints every issue at once and exits with code 1

### `backend/src/index.ts`
Startup order is now explicit and enforced:
1. `dotenv.config()` — load .env file
2. `loadSecrets()` — pull from AWS Secrets Manager
3. `await import('./env')` — validate all vars (dynamic import so secrets
   land in `process.env` first)
4. Service initialisation

### Eliminated raw `process.env` reads

| File | Removed |
|---|---|
| `soroban.ts` | `process.env.SOROBAN_RPC_URL`, `process.env.NETWORK_PASSPHRASE` |
| `logger.ts` | `process.env.SLACK_WEBHOOK_URL`, `process.env.MAINTENANCE_MODE` |
| `indexer/indexer.ts` | `process.env.REWARDS_CONTRACT_ID`, `process.env.CAMPAIGN_CONTRACT_ID` |
| `db.ts` | `process.env.AWS_REGION` |

All replaced with typed `env.*` values.

### `.env.example`
Every variable annotated as `REQUIRED` or `OPTIONAL` with its default,
kept in sync with the Zod schema.

### `backend/src/__tests__/env.test.ts` (new — 45 tests)
- Each required field missing individually → throws with field name in message
- Multiple missing fields reported in a single error
- URL validation for `SOROBAN_RPC_URL`, `DATABASE_URL`, `SLACK_WEBHOOK_URL`
- Boolean coercion for `ENABLE_INDEXER` and `MAINTENANCE_MODE`
- Port coercion, default (3001), boundary rejection (0, 99999, non-numeric)
- Optional fields don't throw when absent
- Defaults verified for `AWS_REGION`, `PORT`, `ENABLE_INDEXER`, `MAINTENANCE_MODE`
- Full happy-path parse of a complete valid environment

