### PR TITLE
feat: campaign expiry countdown timer

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,38 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    name: Type-check, Lint & Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npx tsc --noEmit
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test -- --ci

--- a/frontend/src/__tests__/CampaignCard.test.tsx
+++ b/frontend/src/__tests__/CampaignCard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "./test-utils";
 import { CampaignCard } from "@/components/CampaignCard";
 import { Campaign } from "@/lib/api";
 
@@ -10,6 +10,9 @@ const base: Campaign = {
   active: true,
   total_claimed: 10,
 };
+
+beforeEach(() => jest.useFakeTimers());
+afterEach(() => jest.useRealTimers());
 
 test("renders campaign details", () => {
   render(<CampaignCard campaign={base} />);
@@ -43,11 +46,33 @@ test("shows Inactive badge for inactive campaign", () => {
 test("shows Expired badge for expired campaign", () => {
   const expired = { ...base, expiration: Math.floor(Date.now() / 1000) - 1 };
   render(<CampaignCard campaign={expired} />);
-  expect(screen.getByText(/Expired/i)).toBeInTheDocument();
+  expect(screen.getByText(/Expired/i, { selector: ".badge" })).toBeInTheDocument();
 });
 
 test("disables claim for expired campaign", () => {
   const expired = { ...base, expiration: Math.floor(Date.now() / 1000) - 1 };
   render(<CampaignCard campaign={expired} onClaim={jest.fn()} />);
   expect(screen.getByRole("button")).toBeDisabled();
+});
+
+test("countdown shows days/hours/minutes/seconds for active campaign", () => {
+  render(<CampaignCard campaign={base} />);
+  const countdown = screen.getByTestId("countdown");
+  // May show "Xd Xh Xm Xs left" or "Xh Xm Xs left" depending on exact timing
+  expect(countdown.textContent).toMatch(/(\d+d )?\d+h \d+m \d+s left/);
+});
+
+test("countdown ticks every second", () => {
+  render(<CampaignCard campaign={base} />);
+  const before = screen.getByTestId("countdown").textContent;
+  act(() => { jest.advanceTimersByTime(1000); });
+  const after = screen.getByTestId("countdown").textContent;
+  expect(before).not.toBe(after);
+});
+
+test("shows 'Expired' in countdown when campaign expires", () => {
+  const soonExpired = { ...base, expiration: Math.floor(Date.now() / 1000) + 1 };
+  render(<CampaignCard campaign={soonExpired} />);
+  act(() => { jest.advanceTimersByTime(2000); });
+  expect(screen.getByTestId("countdown").textContent).toBe("Expired");
 });

--- a/frontend/src/__tests__/RewardList.test.tsx
+++ b/frontend/src/__tests__/RewardList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "./test-utils";
 import { RewardList } from "@/components/RewardList";
 import { Reward } from "@/lib/api";
 

--- a/frontend/src/__tests__/WalletConnector.test.tsx
+++ b/frontend/src/__tests__/WalletConnector.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent } from "./test-utils";
 import { WalletConnector } from "@/components/WalletConnector";
 import { WalletContext } from "@/context/WalletContext";
 import React from "react";
@@ -18,6 +18,16 @@ const wrap = (ctx: ReturnType<typeof makeCtx>) =>
     </WalletContext.Provider>
   );
 
+beforeEach(() => {
+  // Simulate Freighter being installed so connect() is called directly
+  Object.defineProperty(window, "freighter", { value: {}, configurable: true });
+});
+
+afterEach(() => {
+  // @ts-expect-error cleanup
+  delete window.freighter;
+});
+
 test("shows Connect button when disconnected", () => {
   wrap(makeCtx());
   expect(screen.getByRole("button", { name: /connect freighter/i })).toBeInTheDocument();
@@ -29,10 +39,12 @@ test("shows connecting state", () => {
   expect(screen.getByRole("button")).toBeDisabled();
 });
 
-test("calls connect on click", () => {
+test("calls connect on click", async () => {
   const ctx = makeCtx();
   wrap(ctx);
   fireEvent.click(screen.getByRole("button"));
+  // handleConnect is async; wait a tick
+  await Promise.resolve();
   expect(ctx.connect).toHaveBeenCalledTimes(1);
 });
 

--- a/frontend/src/__tests__/test-utils.tsx
+++ b/frontend/src/__tests__/test-utils.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { render, RenderOptions } from "@testing-library/react";
+import { I18nProvider } from "@/context/I18nContext";
+
+const AllProviders = ({ children }: { children: React.ReactNode }) => (
+  <I18nProvider>{children}</I18nProvider>
+);
+
+const customRender = (ui: React.ReactElement, options?: RenderOptions) =>
+  render(ui, { wrapper: AllProviders, ...options });
+
+export * from "@testing-library/react";
+export { customRender as render };

--- a/frontend/src/components/CampaignCard.tsx
+++ b/frontend/src/components/CampaignCard.tsx
@@ -1,62 +1,81 @@
 "use client";
 
+import { useRef } from "react";
 import { Campaign } from "@/lib/api";
 import { useI18n } from "@/context/I18nContext";
+import { useCountdown } from "@/hooks/useCountdown";
 
 interface Props {
   campaign: Campaign;
   onClaim?: (id: number) => void;
   claiming?: boolean;
-  optimisticClaimed?: boolean;
 }
 
 export function CampaignCard({ campaign, onClaim, claiming }: Props) {
   const { t } = useI18n();
-  const expired = Date.now() / 1000 > campaign.expiration;
-  const statusKey = !campaign.active ? "inactive" : expired ? "expired" : "active";
+  const countdown = useCountdown(campaign.expiration);
+  const prevMinuteRef = useRef<number | null>(null);
+
+  const isInactive = !campaign.active;
+  const statusKey = isInactive ? "inactive" : countdown.expired ? "expired" : "active";
   const status = t(`campaigns.status.${statusKey}`);
-  const canClaim = campaign.active && !expired;
+  const canClaim = campaign.active && !countdown.expired;
 
-  const secondsLeft = campaign.expiration - now;
-  const daysLeft = Math.floor(secondsLeft / 86400);
-  const hoursLeft = Math.floor((secondsLeft % 86400) / 3600);
+  // Announce to screen readers on each minute change
+  const announceMinute =
+    !countdown.expired &&
+    prevMinuteRef.current !== null &&
+    prevMinuteRef.current !== countdown.minutes;
+  if (prevMinuteRef.current !== countdown.minutes) {
+    prevMinuteRef.current = countdown.minutes;
+  }
 
-  let urgency: "low" | "medium" | "high" | "expired" = "low";
-  if (expired) urgency = "expired";
-  else if (daysLeft < 1) urgency = "high";
-  else if (daysLeft < 3) urgency = "medium";
-
-  const expiryText = expired
+  const countdownLabel = countdown.expired
     ? "Expired"
-    : daysLeft > 0
-    ? `${daysLeft}d ${hoursLeft}h left`
-    : `${hoursLeft}h left`;
+    : countdown.days > 0
+    ? `${countdown.days}d ${countdown.hours}h ${countdown.minutes}m ${countdown.seconds}s left`
+    : `${countdown.hours}h ${countdown.minutes}m ${countdown.seconds}s left`;
 
   return (
     <div className="card" style={{ position: "relative" }}>
-      <Confetti active={!!justClaimed} />
       <div className="card-header">
         <span className="badge" data-status={statusKey}>
           {status}
         </span>
-        <span className="campaign-id">{t('campaigns.details.campaign')} #{campaign.id}</span>
+        <span className="campaign-id">
+          {t("campaigns.details.campaign")} #{campaign.id}
+        </span>
       </div>
       <div className="card-body">
         <p>
-          <strong>{t('campaigns.details.merchant')}:</strong>{" "}
+          <strong>{t("campaigns.details.merchant")}:</strong>{" "}
           <span className="mono">
             {campaign.merchant.slice(0, 8)}…{campaign.merchant.slice(-4)}
           </span>
         </p>
         <p>
-          <strong>{t('campaigns.details.reward')}:</strong> {campaign.reward_amount.toLocaleString()} LYT
+          <strong>{t("campaigns.details.reward")}:</strong>{" "}
+          {campaign.reward_amount.toLocaleString()} LYT
         </p>
         <p>
-          <strong>{t('campaigns.details.claimed')}:</strong> {campaign.total_claimed}
+          <strong>{t("campaigns.details.claimed")}:</strong>{" "}
+          {campaign.total_claimed}
         </p>
         <p>
-          <strong>{t('campaigns.details.expires')}:</strong>{" "}
-          {new Date(campaign.expiration * 1000).toLocaleString()}
+          <strong>{t("campaigns.details.expires")}:</strong>{" "}
+          <span
+            aria-live="off"
+            aria-label={countdownLabel}
+            data-testid="countdown"
+          >
+            {countdownLabel}
+          </span>
+          {/* Announce minute changes to screen readers */}
+          {announceMinute && (
+            <span className="sr-only" aria-live="polite" aria-atomic="true">
+              {countdownLabel}
+            </span>
+          )}
         </p>
       </div>
       {onClaim && (
@@ -66,7 +85,9 @@ export function CampaignCard({ campaign, onClaim, claiming }: Props) {
             disabled={!canClaim || claiming}
             className="btn btn-primary"
           >
-            {claiming ? t('campaigns.actions.claiming') : t('campaigns.actions.claim')}
+            {claiming
+              ? t("campaigns.actions.claiming")
+              : t("campaigns.actions.claim")}
           </button>
         </div>
       )}

--- a/frontend/src/hooks/useCountdown.ts
+++ b/frontend/src/hooks/useCountdown.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from "react";
+
+export interface CountdownResult {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+  expired: boolean;
+}
+
+export function useCountdown(expirationUnix: number): CountdownResult {
+  const calc = (): CountdownResult => {
+    const diff = Math.max(0, expirationUnix - Math.floor(Date.now() / 1000));
+    return {
+      days: Math.floor(diff / 86400),
+      hours: Math.floor((diff % 86400) / 3600),
+      minutes: Math.floor((diff % 3600) / 60),
+      seconds: diff % 60,
+      expired: diff === 0,
+    };
+  };
+
+  const [state, setState] = useState<CountdownResult>(calc);
+
+  useEffect(() => {
+    if (state.expired) return;
+    const id = setInterval(() => {
+      const next = calc();
+      setState(next);
+      if (next.expired) clearInterval(id);
+    }, 1000);
+    return () => clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expirationUnix, state.expired]);
+
+  return state;
+}


### PR DESCRIPTION
close #28 

- Add useCountdown hook with setInterval, cleans up on unmount
- Update CampaignCard to show live days/hours/minutes/seconds countdown
- Show 'Expired' in countdown and disable claim button when expired
- Announce countdown to screen readers on minute change (aria-live)
- Fix broken CampaignCard references (now, Confetti, justClaimed)
- Add test-utils.tsx with I18nProvider wrapper for all component tests
- Fix pre-existing test failures in RewardList, WalletConnector tests
- Add frontend-ci.yml GitHub Actions workflow