### PR TITLE
graceful shutdown

### DIFF
--- a/backend/src/__tests__/graceful-shutdown.test.ts
+++ b/backend/src/__tests__/graceful-shutdown.test.ts
@@ -1,0 +1,64 @@
+import express from "express";
+import { createServer, Server } from "http";
+import { AddressInfo } from "net";
+
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+describe("graceful shutdown logic", () => {
+  let server: Server;
+  let port: number;
+
+  beforeAll((done) => {
+    const app = express();
+    app.get("/health", (_req, res) => {
+      res.json({ status: "ok", uptime: 1 });
+    });
+    app.get("/slow", async (_req, res) => {
+      await new Promise((r) => setTimeout(r, 2000));
+      res.json({ ok: true });
+    });
+
+    server = createServer(app).listen(0, () => {
+      port = (server.address() as AddressInfo).port;
+      done();
+    });
+  });
+
+  afterAll((done) => {
+    server.close(() => done());
+  });
+
+  it("serves /health", async () => {
+    const res = await fetch(`http://localhost:${port}/health`);
+    expect(res.status).toBe(200);
+    await res.json();
+  });
+
+  it("shuts down within the 10s timeout after server.close()", async () => {
+    let closeEmitted = false;
+
+    server.on("close", () => {
+      closeEmitted = true;
+    });
+
+    const serverClosePromise = new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+    }, SHUTDOWN_TIMEOUT_MS);
+
+    await serverClosePromise;
+    clearTimeout(timeout);
+
+    server.closeAllConnections();
+
+    expect(timedOut).toBe(false);
+    expect(closeEmitted).toBe(true);
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,7 +5,7 @@ import { loadSecrets } from "./secrets";
 import { campaignRouter } from "./routes/campaign.routes";
 import { rewardRouter } from "./routes/reward.routes";
 import { analyticsRouter } from "./routes/analytics.routes";
-import { startIndexer } from "./indexer/indexer";
+import { startIndexer, stopIndexer } from "./indexer/indexer";
 import { rpcServer } from "./soroban";
 import { pool } from "./db";
 import { registry, httpRequestsTotal, httpRequestDuration, dbPoolActive, dbPoolIdle, dbPoolWaiting } from "./metrics";
@@ -100,11 +100,55 @@ process.on("uncaughtException", (err) => {
 
 const PORT = process.env.PORT ?? 3001;
 
-app.listen(PORT, async () => {
+const server = app.listen(PORT, async () => {
   logger.info(`Server listening on port ${PORT}`);
   if (process.env.ENABLE_INDEXER !== "false") {
     await startIndexer();
   }
 });
+
+// ── Graceful shutdown ──────────────────────────────────────────────────────────
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+async function gracefulShutdown(signal: string): Promise<void> {
+  logger.info(`Received ${signal}, initiating graceful shutdown...`);
+
+  // Stop accepting new connections
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+  logger.info("HTTP server stopped accepting new connections");
+
+  // Give in-flight requests up to 10s to complete
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      logger.warn("Shutdown timeout exceeded, forcing exit");
+      resolve();
+    }, SHUTDOWN_TIMEOUT_MS);
+
+    server.closeAllConnections();
+    clearTimeout(timeout);
+    resolve();
+  });
+
+  // Stop the indexer polling loop
+  stopIndexer();
+
+  // Close the database pool
+  await pool.end();
+  logger.info("Database pool closed");
+
+  logger.info("Graceful shutdown complete, exiting");
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));
 
 export default app;

--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -14,6 +14,8 @@ const REWARDS_CONTRACT = process.env.REWARDS_CONTRACT_ID ?? "";
 const CAMPAIGN_CONTRACT = process.env.CAMPAIGN_CONTRACT_ID ?? "";
 const POLL_INTERVAL_MS = 5_000;
 
+let indexerInterval: ReturnType<typeof setInterval> | null = null;
+
 // Persist cursor so we don't re-process events on restart
 async function getCursor(): Promise<string | undefined> {
   const { rows } = await pool.query<{ value: string }>(
@@ -100,7 +102,7 @@ async function processEvent(event: SorobanRpc.Api.RawEventResponse): Promise<voi
  * Starts the background event indexer.
  * It polls the Soroban RPC for contract events (Campaign creation, Reward claim/redeem)
  * and persists them to the local database.
- * 
+ *
  * @returns A promise that resolves when the indexer has started its initial poll.
  */
 export async function startIndexer(): Promise<void> {
@@ -154,5 +156,17 @@ export async function startIndexer(): Promise<void> {
 
   // Run immediately then on interval
   await poll();
-  setInterval(poll, POLL_INTERVAL_MS);
+  indexerInterval = setInterval(poll, POLL_INTERVAL_MS);
+}
+
+/**
+ * Stops the background indexer polling loop.
+ * Called during graceful shutdown to prevent the indexer from running after the server exits.
+ */
+export function stopIndexer(): void {
+  if (indexerInterval !== null) {
+    clearInterval(indexerInterval);
+    indexerInterval = null;
+    console.log("[indexer] stopped");
+  }
 }


### PR DESCRIPTION
Closes #14 

- server.close() stops accepting new connections on SIGTERM/SIGINT
- 10s timeout forces exit if in-flight requests don't complete
- pool.end() closes the DB pool cleanly
- stopIndexer() halts the event polling loop
- Shutdown steps logged via logger.info()