### PR TITLE
feat(rewards): implement storage migration pattern with idempotency g…

### DIFF
--- a/contracts/rewards/src/lib.rs
+++ b/contracts/rewards/src/lib.rs
@@ -1,12 +1,10 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol,
+    contract, contractimpl, contracttype, symbol_short, Address, Env, Symbol, Vec,
 };
 
 // ── Cross-contract interfaces ─────────────────────────────────────────────────
-// We define minimal client traits via contractimport for production.
-// Tests use the real crate clients directly.
 
 mod token {
     use soroban_sdk::{contractclient, Address, Env};
@@ -48,16 +46,35 @@ use campaign::Campaign;
 
 #[contracttype]
 pub enum DataKey {
+    /// v2: Claimed(user, campaign_id) → ClaimRecord
     Claimed(Address, u64),
+    /// v1 (legacy): ClaimedV1(user, campaign_id) → bool
+    /// Kept during migration; removed after migrate() completes.
+    ClaimedV1(Address, u64),
     TokenContract,
     CampaignContract,
     Admin,
+    /// Schema version — bumped by each migration
+    SchemaVersion,
+    /// Idempotency guard: set to true once migrate_v1_to_v2 completes
+    MigrationV1Done,
+}
+
+// ── Storage types ─────────────────────────────────────────────────────────────
+
+/// v2 claim record — richer than the v1 bool
+#[contracttype]
+#[derive(Clone)]
+pub struct ClaimRecord {
+    pub amount: i128,
+    pub claimed_at: u64,
 }
 
 // ── Events ────────────────────────────────────────────────────────────────────
 
 const REWARD_CLAIMED: Symbol = symbol_short!("RWD_CLM");
 const REWARD_REDEEMED: Symbol = symbol_short!("RWD_RDM");
+const MIGRATED: Symbol = symbol_short!("MIGRATED");
 
 // ── Contract ──────────────────────────────────────────────────────────────────
 
@@ -103,9 +120,13 @@ impl RewardsContract {
     }
 
     fn has_claimed(env: &Env, user: &Address, campaign_id: u64) -> bool {
+        // Check v2 first, then fall back to v1 (pre-migration)
         env.storage()
             .persistent()
             .has(&DataKey::Claimed(user.clone(), campaign_id))
+            || env.storage()
+                .persistent()
+                .has(&DataKey::ClaimedV1(user.clone(), campaign_id))
     }
 
     /// Returns multiplier in basis points (10000 = 1x, 20000 = 2x).
@@ -138,10 +159,14 @@ impl RewardsContract {
 
         let campaign: Campaign = campaign_client.get_campaign(&campaign_id);
 
-        // Write claimed state before external mint (reentrancy guard)
+        // Write claimed state before external mint (reentrancy guard) — v2 record
+        let record = ClaimRecord {
+            amount: 0, // will be updated below; set 0 now to mark as claimed
+            claimed_at: env.ledger().timestamp(),
+        };
         env.storage()
             .persistent()
-            .set(&DataKey::Claimed(user.clone(), campaign_id), &true);
+            .set(&DataKey::Claimed(user.clone(), campaign_id), &record);
 
         let multiplier_bp = Self::calc_multiplier(
             env.ledger().timestamp(),
@@ -152,6 +177,15 @@ impl RewardsContract {
 
         campaign_client.record_claim(&campaign_id);
         Self::token_client(&env).mint(&user, &final_amount);
+
+        // Update record with actual amount
+        let record = ClaimRecord {
+            amount: final_amount,
+            claimed_at: env.ledger().timestamp(),
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Claimed(user.clone(), campaign_id), &record);
 
         env.events().publish(
             (REWARD_CLAIMED, symbol_short!("user"), user.clone()),
@@ -171,6 +205,71 @@ impl RewardsContract {
 
     pub fn has_claimed_view(env: Env, user: Address, campaign_id: u64) -> bool {
         Self::has_claimed(&env, &user, campaign_id)
+    }
+
+    pub fn schema_version(env: Env) -> u32 {
+        env.storage().instance().get(&DataKey::SchemaVersion).unwrap_or(1)
+    }
+
+    // ── Storage Migration ─────────────────────────────────────────────────────
+
+    /// Migrate v1 claim records (bool) to v2 (ClaimRecord) for a batch of entries.
+    ///
+    /// # Idempotency
+    /// Guarded by `MigrationV1Done` flag — panics if called a second time.
+    ///
+    /// # Admin-only
+    /// Requires admin auth.
+    ///
+    /// # Usage
+    /// Call once after deploying the v2 contract upgrade, passing all
+    /// (user, campaign_id) pairs that were claimed under v1.
+    /// Old `ClaimedV1` keys are removed after writing the new `Claimed` records.
+    ///
+    /// # Rollback
+    /// If migration fails mid-batch, the `MigrationV1Done` flag is NOT set
+    /// (it is only set on success), so the function can be retried.
+    /// To roll back to v1 entirely, redeploy the v1 wasm and the v1 keys
+    /// remain intact (they are only removed on successful migration).
+    pub fn migrate_v1_to_v2(
+        env: Env,
+        admin: Address,
+        entries: Vec<(Address, u64)>,
+    ) {
+        admin.require_auth();
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        assert!(admin == stored_admin, "not admin");
+
+        // Idempotency guard
+        assert!(
+            !env.storage().instance().has(&DataKey::MigrationV1Done),
+            "migration already completed"
+        );
+
+        let now = env.ledger().timestamp();
+
+        for (user, campaign_id) in entries.iter() {
+            let v1_key = DataKey::ClaimedV1(user.clone(), campaign_id);
+            let v2_key = DataKey::Claimed(user.clone(), campaign_id);
+
+            // Only migrate if v1 record exists and v2 doesn't yet
+            if env.storage().persistent().has(&v1_key)
+                && !env.storage().persistent().has(&v2_key)
+            {
+                let record = ClaimRecord {
+                    amount: 0, // amount unknown from v1 bool; set 0 as sentinel
+                    claimed_at: now,
+                };
+                env.storage().persistent().set(&v2_key, &record);
+                env.storage().persistent().remove(&v1_key);
+            }
+        }
+
+        // Mark migration complete and bump schema version
+        env.storage().instance().set(&DataKey::MigrationV1Done, &true);
+        env.storage().instance().set(&DataKey::SchemaVersion, &2_u32);
+
+        env.events().publish(MIGRATED, 2_u32);
     }
 }
 
@@ -471,8 +570,84 @@ mod tests {
         assert_eq!(t.token.total_supply_view(), 0);
         assert!(!t.rewards.has_claimed_view(&user, &campaign_id));
     }
-        assert_eq!(t.token.balance(&user1), 100);
-        assert_eq!(t.token.balance(&user2), 100);
-        assert_eq!(t.token.total_supply_view(), 200);
+
+    // ── Migration Tests (Issue #119) ──────────────────────────────────────────
+
+    #[test]
+    fn test_migration_v1_to_v2_idempotent_guard() {
+        let t = setup();
+        let admin = Address::generate(&t.env);
+        // Re-initialize with known admin for migration test
+        let rewards_id = t.env.register_contract(None, RewardsContract);
+        let rewards = RewardsContractClient::new(&t.env, &rewards_id);
+        rewards.initialize(&admin, &t.token.address, &t.campaign.address);
+
+        let entries: soroban_sdk::Vec<(Address, u64)> = soroban_sdk::Vec::new(&t.env);
+
+        // First call succeeds
+        rewards.migrate_v1_to_v2(&admin, &entries);
+        assert_eq!(rewards.schema_version(), 2);
+
+        // Second call panics
+        let result = std::panic::catch_unwind(|| {
+            rewards.migrate_v1_to_v2(&admin, &entries);
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_migration_converts_v1_records() {
+        let t = setup();
+        let admin = Address::generate(&t.env);
+        let user1 = Address::generate(&t.env);
+        let user2 = Address::generate(&t.env);
+
+        let rewards_id = t.env.register_contract(None, RewardsContract);
+        let rewards = RewardsContractClient::new(&t.env, &rewards_id);
+        rewards.initialize(&admin, &t.token.address, &t.campaign.address);
+
+        // Simulate v1 state: write ClaimedV1 bool records directly
+        t.env.as_contract(&rewards_id, || {
+            t.env.storage().persistent().set(&DataKey::ClaimedV1(user1.clone(), 1), &true);
+            t.env.storage().persistent().set(&DataKey::ClaimedV1(user2.clone(), 1), &true);
+        });
+
+        // Both users appear claimed via v1 fallback
+        assert!(rewards.has_claimed_view(&user1, &1));
+        assert!(rewards.has_claimed_view(&user2, &1));
+
+        // Run migration
+        let mut entries: soroban_sdk::Vec<(Address, u64)> = soroban_sdk::Vec::new(&t.env);
+        entries.push_back((user1.clone(), 1));
+        entries.push_back((user2.clone(), 1));
+        rewards.migrate_v1_to_v2(&admin, &entries);
+
+        // v1 keys removed, v2 keys present — still appears claimed
+        assert!(rewards.has_claimed_view(&user1, &1));
+        assert!(rewards.has_claimed_view(&user2, &1));
+
+        // Schema version bumped
+        assert_eq!(rewards.schema_version(), 2);
+
+        // v1 keys are gone
+        t.env.as_contract(&rewards_id, || {
+            assert!(!t.env.storage().persistent().has(&DataKey::ClaimedV1(user1.clone(), 1)));
+            assert!(!t.env.storage().persistent().has(&DataKey::ClaimedV1(user2.clone(), 1)));
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "not admin")]
+    fn test_migration_non_admin_rejected() {
+        let t = setup();
+        let admin = Address::generate(&t.env);
+        let outsider = Address::generate(&t.env);
+
+        let rewards_id = t.env.register_contract(None, RewardsContract);
+        let rewards = RewardsContractClient::new(&t.env, &rewards_id);
+        rewards.initialize(&admin, &t.token.address, &t.campaign.address);
+
+        let entries: soroban_sdk::Vec<(Address, u64)> = soroban_sdk::Vec::new(&t.env);
+        rewards.migrate_v1_to_v2(&outsider, &entries);
     }
 }

--- a/docs/storage-migration.md
+++ b/docs/storage-migration.md
@@ -1,0 +1,222 @@
+# Storage Migration Guide
+
+## Overview
+
+When a Soroban contract upgrade changes the storage schema (adds fields, changes types, renames keys), existing on-chain data must be migrated to the new format. This guide documents the migration pattern used in SorobanLoyalty contracts and the procedure for executing and rolling back migrations.
+
+## Pattern
+
+### Key Principles
+
+1. **Idempotency guard** — a `MigrationVNDone` flag in instance storage prevents the migration from running twice
+2. **Admin-only** — migration requires admin auth; unauthorized callers are rejected
+3. **Old key cleanup** — after writing new-format records, old keys are removed
+4. **Schema version** — `SchemaVersion` in instance storage tracks the current version
+5. **Backward-compatible reads** — during the migration window, reads check both old and new keys so the contract remains functional before migration runs
+
+### Storage Key Versioning
+
+```rust
+#[contracttype]
+pub enum DataKey {
+    // v2 (current)
+    Claimed(Address, u64),          // → ClaimRecord { amount, claimed_at }
+
+    // v1 (legacy — present only before migration completes)
+    ClaimedV1(Address, u64),        // → bool
+
+    // Migration state
+    SchemaVersion,                  // → u32
+    MigrationV1Done,                // → bool
+}
+```
+
+### Migration Function Signature
+
+```rust
+pub fn migrate_v1_to_v2(
+    env: Env,
+    admin: Address,
+    entries: Vec<(Address, u64)>,   // (user, campaign_id) pairs to migrate
+)
+```
+
+### Implementation
+
+```rust
+pub fn migrate_v1_to_v2(env: Env, admin: Address, entries: Vec<(Address, u64)>) {
+    admin.require_auth();
+    let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+    assert!(admin == stored_admin, "not admin");
+
+    // Idempotency guard
+    assert!(
+        !env.storage().instance().has(&DataKey::MigrationV1Done),
+        "migration already completed"
+    );
+
+    let now = env.ledger().timestamp();
+
+    for (user, campaign_id) in entries.iter() {
+        let v1_key = DataKey::ClaimedV1(user.clone(), campaign_id);
+        let v2_key = DataKey::Claimed(user.clone(), campaign_id);
+
+        if env.storage().persistent().has(&v1_key)
+            && !env.storage().persistent().has(&v2_key)
+        {
+            let record = ClaimRecord { amount: 0, claimed_at: now };
+            env.storage().persistent().set(&v2_key, &record);
+            env.storage().persistent().remove(&v1_key);
+        }
+    }
+
+    env.storage().instance().set(&DataKey::MigrationV1Done, &true);
+    env.storage().instance().set(&DataKey::SchemaVersion, &2_u32);
+    env.events().publish(MIGRATED, 2_u32);
+}
+```
+
+### Backward-Compatible Read
+
+During the migration window (after upgrade, before migration runs), reads check both keys:
+
+```rust
+fn has_claimed(env: &Env, user: &Address, campaign_id: u64) -> bool {
+    env.storage().persistent().has(&DataKey::Claimed(user.clone(), campaign_id))
+        || env.storage().persistent().has(&DataKey::ClaimedV1(user.clone(), campaign_id))
+}
+```
+
+## Execution Procedure
+
+### Prerequisites
+
+1. Deploy the upgraded contract wasm (containing both old and new key support)
+2. Collect all `(user, campaign_id)` pairs that were claimed under v1 — query the `transactions` table:
+   ```sql
+   SELECT DISTINCT user_address, campaign_id
+   FROM transactions
+   WHERE type = 'claim'
+   ORDER BY user_address;
+   ```
+
+### Step-by-Step
+
+1. **Deploy upgraded contract**
+   ```bash
+   ./scripts/deploy-contracts.sh testnet $SECRET_KEY
+   ```
+
+2. **Verify schema version is still 1**
+   ```bash
+   stellar contract invoke \
+     --id $REWARDS_CONTRACT_ID \
+     --source $ADMIN_KEY \
+     -- schema_version
+   # Expected: 1
+   ```
+
+3. **Prepare migration entries** (batch into chunks of ≤100 to stay within gas limits)
+   ```bash
+   # Query DB for all claimed entries
+   psql $DATABASE_URL -c "
+     SELECT user_address, campaign_id
+     FROM transactions WHERE type = 'claim'
+   " --csv > claimed_entries.csv
+   ```
+
+4. **Run migration** (repeat for each batch)
+   ```bash
+   stellar contract invoke \
+     --id $REWARDS_CONTRACT_ID \
+     --source $ADMIN_KEY \
+     -- migrate_v1_to_v2 \
+     --admin $ADMIN_ADDRESS \
+     --entries '[["USER_ADDR_1", 1], ["USER_ADDR_2", 2]]'
+   ```
+
+5. **Verify migration completed**
+   ```bash
+   stellar contract invoke \
+     --id $REWARDS_CONTRACT_ID \
+     --source $ADMIN_KEY \
+     -- schema_version
+   # Expected: 2
+   ```
+
+6. **Verify no v1 keys remain** (spot-check a few users)
+   ```bash
+   stellar contract invoke \
+     --id $REWARDS_CONTRACT_ID \
+     --source $ADMIN_KEY \
+     -- has_claimed_view \
+     --user $SAMPLE_USER \
+     --campaign_id 1
+   # Expected: true (served from v2 key)
+   ```
+
+## Rollback Procedure
+
+The migration is designed to be safe to retry but not automatically reversible. If migration fails mid-batch:
+
+### Scenario A: Migration panicked before setting `MigrationV1Done`
+
+The idempotency flag was not set, so the migration can be retried from the beginning. The v1 keys for already-migrated entries are gone, but `has_claimed` still returns `true` via the v2 key.
+
+**Action**: Fix the root cause and re-run `migrate_v1_to_v2` with the full entry list.
+
+### Scenario B: Need to roll back to v1 contract
+
+If the v2 contract has a critical bug and must be rolled back:
+
+1. **Redeploy v1 wasm** (requires the upgrade multi-sig flow)
+   ```bash
+   stellar contract invoke \
+     --id $CAMPAIGN_CONTRACT_ID \
+     --source $ADMIN_KEY \
+     -- propose_upgrade \
+     --admin $ADMIN_ADDRESS \
+     --wasm_hash $V1_WASM_HASH
+   # ... approve and execute upgrade
+   ```
+
+2. **Restore v1 claim records** from the `transactions` table:
+   ```bash
+   # For each claimed entry, write ClaimedV1 key back
+   # (requires a one-off recovery script using the Soroban SDK)
+   ```
+
+> **Note**: Rolling back after a completed migration requires a recovery script to re-write `ClaimedV1` keys. Always test migrations on testnet before mainnet.
+
+## Testing
+
+### Unit Tests
+
+```bash
+cargo test -p soroban-loyalty-rewards -- migration
+```
+
+Tests cover:
+- `test_migration_v1_to_v2_idempotent_guard` — second call panics
+- `test_migration_converts_v1_records` — v1 keys removed, v2 keys written, `has_claimed` still true
+- `test_migration_non_admin_rejected` — non-admin panics
+
+### Realistic Data Volume
+
+The migration function accepts a `Vec<(Address, u64)>` batch. For large datasets, call in batches of 50–100 entries per transaction to stay within Soroban's instruction limits (~100M instructions per transaction).
+
+Estimate batch size:
+- Each entry: ~2 storage reads + 1 write + 1 remove ≈ ~500K instructions
+- Safe batch: 100 entries ≈ 50M instructions (well within 100M limit)
+
+## Adding Future Migrations
+
+Follow this checklist for each new migration:
+
+- [ ] Add new `DataKey` variants for new format (keep old variants with `V{N}` suffix)
+- [ ] Add `MigrationV{N}Done` idempotency key
+- [ ] Implement `migrate_v{N}_to_v{N+1}` with admin auth + idempotency guard
+- [ ] Update reads to check both old and new keys during migration window
+- [ ] Write tests: idempotency, data conversion, admin-only, old key cleanup
+- [ ] Document rollback procedure
+- [ ] Test on testnet with realistic data volume before mainnet


### PR DESCRIPTION
…uard

- Add ClaimedV1 legacy key and ClaimRecord v2 type to rewards contract
- migrate_v1_to_v2: admin-only, idempotent (MigrationV1Done guard), converts bool→ClaimRecord, removes old ClaimedV1 keys, bumps SchemaVersion
- has_claimed reads v2 first, falls back to v1 during migration window
- schema_version view function
- Tests: idempotency guard, data conversion + old key cleanup, non-admin rejection
- docs/storage-migration.md: pattern, execution procedure, rollback procedure, batch sizing guidance, future migration checklist

Closes #119 

## Pull Request Checklist

Before submitting your PR, please review the following checklist:

- [ ] I have run tests locally and they all pass.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have added appropriate tests for new features or bug fixes.
- [ ] **Smart Contract Changes**: If I modified anything under `contracts/`, I updated `docs/audits/smart-contract-audit-status.yml` to reflect whether a re-audit is now required.
- [ ] **Database Schema Changes**: If I altered `schema.sql`, I have:
  - [ ] Updated the ERD (`docs/erd.png`).
  - [ ] Updated the schema documentation in `docs/database.md`.
- [ ] Runbook / Operations documentation is updated if necessary.
- [ ] **Changelog & Versioning**:
  - [ ] I have updated the `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/) format.
  - [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `BREAKING CHANGE:`).
