### PR TITLE
feat(frontend): add reusable ConfirmDialog for irreversible actions

### DIFF
--- a/frontend/src/components/CampaignTable.tsx
+++ b/frontend/src/components/CampaignTable.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { Campaign } from "@/lib/api";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 type SortKey = "id" | "reward_amount" | "total_claimed" | "expiration";
 type SortDir = "asc" | "desc";
@@ -122,34 +123,14 @@ export function CampaignTable({ campaigns, onDeactivate }: Props) {
                   </td>
                   {onDeactivate && (
                     <td style={{ padding: "10px 12px" }}>
-                      {confirmId === c.id ? (
-                        <span style={{ display: "flex", gap: 6 }}>
-                          <button
-                            className="btn btn-outline"
-                            style={{ padding: "4px 10px", fontSize: "0.75rem" }}
-                            onClick={() => setConfirmId(null)}
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            className="btn btn-primary"
-                            style={{ padding: "4px 10px", fontSize: "0.75rem", background: "#dc2626" }}
-                            disabled={deactivating === c.id}
-                            onClick={() => handleDeactivate(c.id)}
-                          >
-                            {deactivating === c.id ? "…" : "Confirm"}
-                          </button>
-                        </span>
-                      ) : (
-                        <button
-                          className="btn btn-outline"
-                          style={{ padding: "4px 10px", fontSize: "0.75rem" }}
-                          disabled={!c.active}
-                          onClick={() => setConfirmId(c.id)}
-                        >
-                          Deactivate
-                        </button>
-                      )}
+                      <button
+                        className="btn btn-outline"
+                        style={{ padding: "4px 10px", fontSize: "0.75rem" }}
+                        disabled={!c.active}
+                        onClick={() => setConfirmId(c.id)}
+                      >
+                        Deactivate
+                      </button>
                     </td>
                   )}
                 </tr>
@@ -170,6 +151,16 @@ export function CampaignTable({ campaigns, onDeactivate }: Props) {
           </button>
         </div>
       )}
+
+      <ConfirmDialog
+        open={confirmId !== null}
+        title="Deactivate campaign?"
+        description={`Campaign #${confirmId} will be deactivated immediately. Users will no longer be able to claim rewards. This cannot be undone from this interface.`}
+        confirmLabel="Deactivate"
+        loading={deactivating !== null}
+        onConfirm={() => confirmId !== null && handleDeactivate(confirmId)}
+        onCancel={() => setConfirmId(null)}
+      />
     </div>
   );
 }

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { FocusTrap } from "./FocusTrap";
+
+interface Props {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  loading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Accessible confirmation dialog for irreversible actions.
+ * - Cancel button is focused by default (safe default).
+ * - Confirm button uses destructive red styling.
+ * - Focus is trapped while open (WCAG 2.1 AA).
+ * - Closes on Escape key.
+ */
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  loading = false,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    // Focus cancel button when dialog opens
+    cancelRef.current?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+      aria-describedby="confirm-dialog-desc"
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0,0,0,0.6)",
+      }}
+    >
+      <FocusTrap active={open}>
+        <div
+          style={{
+            background: "#1a1d27",
+            border: "1px solid #2d3148",
+            borderRadius: 12,
+            padding: "24px 28px",
+            maxWidth: 420,
+            width: "90vw",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.5)",
+          }}
+        >
+          <h2
+            id="confirm-dialog-title"
+            style={{ margin: "0 0 8px", fontSize: "1.1rem", fontWeight: 700, color: "#e2e8f0" }}
+          >
+            {title}
+          </h2>
+          <p
+            id="confirm-dialog-desc"
+            style={{ margin: "0 0 20px", color: "#94a3b8", fontSize: "0.9rem", lineHeight: 1.5 }}
+          >
+            {description}
+          </p>
+          <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
+            <button
+              ref={cancelRef}
+              className="btn btn-outline"
+              onClick={onCancel}
+              disabled={loading}
+              style={{ minWidth: 80 }}
+            >
+              {cancelLabel}
+            </button>
+            <button
+              className="btn btn-primary"
+              onClick={onConfirm}
+              disabled={loading}
+              style={{ minWidth: 80, background: "#dc2626", borderColor: "#dc2626" }}
+            >
+              {loading ? "Processing…" : confirmLabel}
+            </button>
+          </div>
+        </div>
+      </FocusTrap>
+    </div>
+  );
+}

--- a/frontend/src/components/RedeemForm.tsx
+++ b/frontend/src/components/RedeemForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useSorobanTransaction } from "@/hooks/useSorobanTransaction";
 import { SorobanErrorBoundary } from "./SorobanErrorBoundary";
+import { ConfirmDialog } from "./ConfirmDialog";
 
 interface Props {
   balance: number;
@@ -11,12 +12,12 @@ interface Props {
 
 function RedeemFormContent({ balance, onRedeem }: Props) {
   const [amount, setAmount] = useState("");
-  const [step, setStep] = useState<"input" | "confirm">("input");
+  const [confirming, setConfirming] = useState(false);
   const { execute, loading, error, clearError } = useSorobanTransaction({
     showToast: true,
     onSuccess: () => {
       setAmount("");
-      setStep("input");
+      setConfirming(false);
       clearError();
     }
   });
@@ -26,7 +27,6 @@ function RedeemFormContent({ balance, onRedeem }: Props) {
 
   const handleConfirm = async () => {
     if (!isValid) return;
-    
     await execute(async () => {
       await onRedeem(parsed);
     });
@@ -43,12 +43,12 @@ function RedeemFormContent({ balance, onRedeem }: Props) {
         </div>
 
         {error && (
-          <div className="alert alert-error" style={{ marginBottom: '1rem' }}>
+          <div className="alert alert-error" style={{ marginBottom: "1rem" }}>
             {error.userMessage}
             {error.shouldShowRetry && (
-              <button 
+              <button
                 onClick={handleConfirm}
-                style={{ marginLeft: '0.5rem', textDecoration: 'underline' }}
+                style={{ marginLeft: "0.5rem", textDecoration: "underline" }}
               >
                 Retry
               </button>
@@ -56,67 +56,42 @@ function RedeemFormContent({ balance, onRedeem }: Props) {
           </div>
         )}
 
-        {open && (
-          <div style={{ marginBottom: 16 }}>
-            <TransactionProgress steps={steps} onRetry={reset} />
-          </div>
-        )}
+        <div className="form-group">
+          <label>Amount to Redeem (LYT)</label>
+          <input
+            type="number"
+            min="1"
+            max={balance}
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            placeholder={`Max ${balance.toLocaleString()}`}
+            disabled={loading}
+          />
+          {amount && !isValid && (
+            <span style={{ fontSize: "0.8rem", color: "#f87171" }}>
+              {parsed > balance ? "Exceeds balance" : "Enter a valid amount"}
+            </span>
+          )}
+        </div>
 
-        {step === "input" ? (
-          <>
-            <div className="form-group">
-              <label>Amount to Redeem (LYT)</label>
-              <input
-                type="number"
-                min="1"
-                max={balance}
-                value={amount}
-                onChange={(e) => setAmount(e.target.value)}
-                placeholder={`Max ${balance.toLocaleString()}`}
-                disabled={loading}
-              />
-              {amount && !isValid && (
-                <span style={{ fontSize: "0.8rem", color: "#f87171" }}>
-                  {parsed > balance ? "Exceeds balance" : "Enter a valid amount"}
-                </span>
-              )}
-            </div>
-            <button
-              className="btn btn-primary"
-              disabled={!isValid || loading}
-              onClick={() => setStep("confirm")}
-              style={{ width: "100%" }}
-            >
-              Redeem LYT
-            </button>
-          </>
-        ) : (
-          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
-            <p style={{ color: "#94a3b8" }}>
-              You are about to burn{" "}
-              <strong style={{ color: "#f87171" }}>{parsed.toLocaleString()} LYT</strong>.
-              This action cannot be undone.
-            </p>
-            <div style={{ display: "flex", gap: 8 }}>
-              <button
-                className="btn btn-outline"
-                onClick={() => setStep("input")}
-                disabled={open}
-                style={{ flex: 1 }}
-              >
-                Cancel
-              </button>
-              <button
-                className="btn btn-primary"
-                onClick={handleConfirm}
-                disabled={open}
-                style={{ flex: 1 }}
-              >
-                {loading ? "Processing..." : "Confirm & Burn"}
-              </button>
-            </div>
-          </div>
-        )}
+        <button
+          className="btn btn-primary"
+          disabled={!isValid || loading}
+          onClick={() => setConfirming(true)}
+          style={{ width: "100%" }}
+        >
+          Redeem LYT
+        </button>
+
+        <ConfirmDialog
+          open={confirming}
+          title="Burn LYT tokens?"
+          description={`You are about to permanently burn ${isValid ? parsed.toLocaleString() : "0"} LYT. This action cannot be undone.`}
+          confirmLabel="Confirm & Burn"
+          loading={loading}
+          onConfirm={handleConfirm}
+          onCancel={() => setConfirming(false)}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
- ConfirmDialog component: accessible, focus-trapped, keyboard-navigable
- Cancel button auto-focused on open (safe default per UX best practice)
- Confirm button uses destructive red (#dc2626)
- Escape key closes dialog
- ARIA: role=dialog, aria-modal, aria-labelledby, aria-describedby
- Focus trapped via existing FocusTrap component (WCAG 2.1 AA)
- Used in RedeemForm: confirms LYT burn with amount and consequence text
- Used in CampaignTable: confirms campaign deactivation with campaign ID
- Loading state disables both buttons and shows 'Processing...' on confirm

Closes #48

## Pull Request Checklist

Before submitting your PR, please review the following checklist:

- [ ] I have run tests locally and they all pass.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have added appropriate tests for new features or bug fixes.
- [ ] **Smart Contract Changes**: If I modified anything under `contracts/`, I updated `docs/audits/smart-contract-audit-status.yml` to reflect whether a re-audit is now required.
- [ ] **Database Schema Changes**: If I altered `schema.sql`, I have:
  - [ ] Updated the ERD (`docs/erd.png`).
  - [ ] Updated the schema documentation in `docs/database.md`.
- [ ] Runbook / Operations documentation is updated if necessary.
- [ ] **Changelog & Versioning**:
  - [ ] I have updated the `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/) format.
  - [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `BREAKING CHANGE:`).
