### PR TITLE
feat: add coverage reporting and 70% threshold enforcement

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -35,7 +35,15 @@ jobs:
         run: npm run lint
 
       - name: Test
-        run: npm test -- --ci
+        run: npm test -- --ci --coverage
+
+      - name: Upload test coverage
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-test-coverage
+          path: frontend/coverage/
+          retention-days: 7
 
   trivy-scan:
     name: Trivy Image Scan

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 .next/
 dist/
 build/
+coverage/
 .env
 .env.local
 *.log

--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -5,6 +5,10 @@ const config: Config = {
   testEnvironment: "node",
   testMatch: ["**/__tests__/**/*.test.ts"],
   collectCoverageFrom: ["src/**/*.ts", "!src/index.ts"],
+  coverageReporters: ["text", "lcov"],
+  coverageThreshold: {
+    global: { lines: 70, functions: 70, branches: 70, statements: 70 },
+  },
   setupFiles: ["<rootDir>/src/__tests__/setup.ts"],
   moduleNameMapper: {
     "^.*/soroban$": "<rootDir>/src/__mocks__/soroban.ts",

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "dev": "ts-node-dev --respawn src/index.ts",
     "lint": "eslint src --ext .ts",
     "typecheck": "tsc --noEmit",
-    "test": "jest",
+    "test": "jest --coverage",
     "test:integration": "NODE_ENV=test jest --config jest.integration.config.ts --runInBand --coverage",
     "test:reward-query-plan": "NODE_ENV=test jest src/services/__tests__/reward.service.test.ts --runInBand"
   },

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -9,6 +9,11 @@ const config = {
     "^@stellar/stellar-sdk$": "<rootDir>/src/__mocks__/stellar-sdk.ts",
   },
   testMatch: ["**/__tests__/**/*.test.tsx"],
+  collectCoverageFrom: ["src/**/*.{ts,tsx}", "!src/**/*.d.ts"],
+  coverageReporters: ["text", "lcov"],
+  coverageThreshold: {
+    global: { lines: 70, functions: 70, branches: 70, statements: 70 },
+  },
 };
 
 module.exports = config;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest --coverage",
   },
   "dependencies": {
     "@sentry/nextjs": "8.53.0",


### PR DESCRIPTION
Closes #397

---

## Summary
Adds test coverage measurement and CI enforcement.

## Changes
- `backend/jest.config.ts` + `frontend/jest.config.js` — `coverageReporters: ["text", "lcov"]` and 70% threshold (lines/functions/branches/statements)
- `backend/package.json` + `frontend/package.json` — `npm test` runs with `--coverage`
- `.github/workflows/frontend-ci.yml` — passes `--coverage` and uploads `frontend-test-coverage` artifact
- `.gitignore` — excludes `coverage/`

## Notes
Backend CI already uploaded coverage artifacts; only frontend CI needed updating. Threshold enforcement is at the Jest level — CI fails automatically if any metric drops below 70%.