### PR TITLE
feat(backend): add owner_address to campaigns table and routes

### DIFF
--- a/backend/src/routes/campaign.routes.ts
+++ b/backend/src/routes/campaign.routes.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   getCampaigns,
   getCampaignById,
+  upsertCampaign,
   reorderCampaigns,
   softDeleteCampaign,
   restoreCampaign,
@@ -13,7 +14,9 @@ import { logger } from "../logger";
 import { asyncHandler } from "../middleware/errorHandler";
 import { validateBody, validateParams, validateQuery } from "../middleware/validation";
 import { BadRequestError, NotFoundError } from "../utils/errors";
-import { parseStrictInteger } from "../utils/validation";
+import { parseStrictInteger, isValidStellarAddress } from "../utils/validation";
+import { requireAuth, AuthRequest } from "../auth";
+import { sanitizeBody } from "../middleware/sanitize";
 
 export const campaignRouter = Router();
 
@@ -32,7 +35,11 @@ const CampaignQuerySchema = z.object({
     if (!val) return undefined;
     const num = parseInt(val, 10);
     return isNaN(num) ? undefined : num;
-  })
+  }),
+  owner: z.string().optional().refine(
+    val => val === undefined || isValidStellarAddress(val),
+    { message: "owner must be a valid Stellar address (56-character G... key)" }
+  ),
 });
 
 const ReorderSchema = z.object({
@@ -152,6 +159,9 @@ campaignRouter.get("/", asyncHandler(async (req: Request, res: Response) => {
   if (req.query.expires_after) {
     const v = parseInt(String(req.query.expires_after), 10);
     if (!isNaN(v)) filters.expires_after = v;
+  }
+  if (req.query.owner) {
+    filters.owner = String(req.query.owner);
   }
 
   const cacheKey = `campaigns:list:${limit}:${offset}:search=${filters.search ?? ""}:status=${filters.status ?? ""}:expires_before=${filters.expires_before ?? ""}:expires_after=${filters.expires_after ?? ""}`;
@@ -302,14 +312,28 @@ campaignRouter.post("/:id/restore", async (req: Request, res: Response) => {
   }
 });
 
-campaignRouter.post("/", sanitizeBody, async (req: Request, res: Response) => {
-  const parsed = CreateCampaignSchema.safeParse(req.body);
-  if (!parsed.success) return res.status(400).json({ error: parsed.error.flatten() });
-  try {
-    const { name: _name, description: _desc, ...rest } = parsed.data;
-    await upsertCampaign({ ...rest, id: Date.now(), active: true, total_claimed: 0 });
-    res.status(201).json({ ok: true });
-  } catch {
-    res.status(500).json({ error: "Failed to create campaign" });
-  }
+const CreateCampaignSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  reward_amount: z.number().int().positive(),
+  expiration: z.number().int().positive(),
+  merchant: z.string().length(56),
+  tx_hash: z.string().max(64).optional(),
 });
+
+/**
+ * POST /campaigns
+ * Creates a new campaign. Requires authentication.
+ * The authenticated caller's address is stored as owner_address.
+ */
+campaignRouter.post("/", requireAuth, sanitizeBody, validateBody(CreateCampaignSchema), asyncHandler(async (req: Request, res: Response) => {
+  const ownerAddress = (req as AuthRequest).merchantPublicKey;
+  const { name: _name, ...rest } = req.body;
+  await upsertCampaign({
+    ...rest,
+    id: Date.now(),
+    active: true,
+    total_claimed: 0,
+    owner_address: ownerAddress,
+  });
+  res.status(201).json({ ok: true });
+}));

--- a/backend/src/services/campaign.service.ts
+++ b/backend/src/services/campaign.service.ts
@@ -4,6 +4,7 @@ import { writeAuditLog } from "./audit.service";
 export interface Campaign {
   id: number;
   merchant: string;
+  owner_address: string;
   name?: string | null;
   reward_amount: number;
   expiration: number;
@@ -29,14 +30,14 @@ export async function upsertCampaign(c: Omit<Campaign, "created_at" | "display_o
   try {
     await client.query("BEGIN");
     await client.query(
-      `INSERT INTO campaigns (id, merchant, reward_amount, expiration, active, total_claimed, tx_hash, image_url)
-       VALUES ($1,$2,$3,$4,$5,$6,$7, $8)
+      `INSERT INTO campaigns (id, merchant, owner_address, reward_amount, expiration, active, total_claimed, tx_hash, image_url)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
        ON CONFLICT (id) DO UPDATE SET
          active = EXCLUDED.active,
          total_claimed = EXCLUDED.total_claimed,
          image_url = COALESCE(EXCLUDED.image_url, campaigns.image_url),
          updated_at = NOW()`,
-      [c.id, c.merchant, c.reward_amount, c.expiration, c.active, c.total_claimed, c.tx_hash ?? null, (c as any).image_url ?? null]
+      [c.id, c.merchant, c.owner_address ?? c.merchant, c.reward_amount, c.expiration, c.active, c.total_claimed, c.tx_hash ?? null, (c as any).image_url ?? null]
     );
     await writeAuditLog({
       actor: c.merchant,
@@ -90,6 +91,7 @@ export interface CampaignFilters {
   status?: "active" | "inactive";
   expires_before?: number;
   expires_after?: number;
+  owner?: string;
 }
 
 /**
@@ -125,6 +127,10 @@ export async function getCampaigns(
   if (filters.expires_after !== undefined) {
     params.push(filters.expires_after);
     conditions.push(`expiration >= $${params.length}`);
+  }
+  if (filters.owner !== undefined) {
+    params.push(filters.owner);
+    conditions.push(`owner_address = $${params.length}`);
   }
 
   const where = conditions.join(" AND ");

--- a/database/migrations/004_add_campaign_owner_address.sql
+++ b/database/migrations/004_add_campaign_owner_address.sql
@@ -1,0 +1,14 @@
+-- Migration: Add owner_address to campaigns table
+-- owner_address stores the Stellar public key of the campaign creator
+-- for ownership-based access control.
+
+ALTER TABLE campaigns ADD COLUMN IF NOT EXISTS owner_address VARCHAR(56);
+
+-- Backfill existing rows: use merchant as the owner (same creator address)
+UPDATE campaigns SET owner_address = merchant WHERE owner_address IS NULL;
+
+-- Enforce NOT NULL after backfill
+ALTER TABLE campaigns ALTER COLUMN owner_address SET NOT NULL;
+
+-- Index for ?owner=:address filter
+CREATE INDEX IF NOT EXISTS idx_campaigns_owner ON campaigns(owner_address);


### PR DESCRIPTION
- Migration 004: adds owner_address VARCHAR(56) NOT NULL, backfills from merchant, adds index
- Campaign interface and upsertCampaign updated to include owner_address
- CampaignFilters extended with owner field for GET /campaigns?owner=:address
- POST /campaigns now requires auth and stores caller address as owner_address
- GET /campaigns/:id returns owner_address in response

Closes #325

