### PR TITLE
feat(backend): implement indexer checkpoint persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,10 @@ PORT=3001
 # OPTIONAL — Set to "false" to disable the on-chain event indexer. Default: true
 ENABLE_INDEXER=true
 
+# OPTIONAL — Ledger sequence number to start indexing from on a cold start (no saved checkpoint).
+#   Set to a recent ledger to skip historical replay and reduce startup time. Default: 1 (full history).
+START_LEDGER=1
+
 # OPTIONAL — Log level for backend. Default: info
 # Valid values: debug, info, warn, error
 LOG_LEVEL=info

--- a/backend/src/__tests__/indexer.test.ts
+++ b/backend/src/__tests__/indexer.test.ts
@@ -26,6 +26,7 @@ jest.mock("../env", () => ({
   env: {
     REWARDS_CONTRACT_ID:  "CREWARDS",
     CAMPAIGN_CONTRACT_ID: "CCAMPAIGN",
+    START_LEDGER: 1,
   },
 }));
 
@@ -36,6 +37,8 @@ import {
   getCursor,
   saveCursor,
   ensureIndexerTable,
+  getLastLedger,
+  saveCheckpoint,
 } from "../indexer/indexer";
 import { indexerDeadLetters, indexerPollErrors } from "../metrics";
 import { logger } from "../logger";
@@ -142,6 +145,64 @@ describe("ensureIndexerTable", () => {
     expect(mockPool.query).toHaveBeenCalledWith(
       expect.stringContaining("CREATE TABLE IF NOT EXISTS indexer_state")
     );
+  });
+});
+
+describe("getLastLedger", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns undefined when no last_ledger row exists", async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [] });
+    const ledger = await getLastLedger();
+    expect(ledger).toBeUndefined();
+  });
+
+  it("returns the stored ledger number as an integer", async () => {
+    (mockPool.query as jest.Mock).mockResolvedValueOnce({ rows: [{ value: "42" }] });
+    const ledger = await getLastLedger();
+    expect(ledger).toBe(42);
+  });
+});
+
+describe("saveCheckpoint", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("saves cursor and last_ledger in a single transaction", async () => {
+    // BEGIN, cursor INSERT, last_ledger INSERT, COMMIT
+    (mockPool.query as jest.Mock).mockResolvedValue({ rows: [] });
+    // pool.connect returns a mock client
+    const mockClient = {
+      query: jest.fn().mockResolvedValue({ rows: [] }),
+      release: jest.fn(),
+    };
+    (mockPool as any).connect = jest.fn().mockResolvedValue(mockClient);
+
+    await saveCheckpoint("token-100", 100);
+
+    const calls = mockClient.query.mock.calls.map(([sql]: [string]) => sql);
+    expect(calls[0]).toBe("BEGIN");
+    expect(calls[1]).toContain("INSERT INTO indexer_state");
+    expect(calls[1]).toContain("cursor");
+    expect(calls[2]).toContain("INSERT INTO indexer_state");
+    expect(calls[2]).toContain("last_ledger");
+    expect(calls[3]).toBe("COMMIT");
+    expect(mockClient.release).toHaveBeenCalled();
+  });
+
+  it("rolls back and rethrows on error", async () => {
+    const mockClient = {
+      query: jest.fn()
+        .mockResolvedValueOnce({}) // BEGIN
+        .mockRejectedValueOnce(new Error("db error")), // cursor INSERT fails
+      release: jest.fn(),
+    };
+    (mockPool as any).connect = jest.fn().mockResolvedValue(mockClient);
+
+    await expect(saveCheckpoint("bad-token", 99)).rejects.toThrow("db error");
+
+    const calls = mockClient.query.mock.calls.map(([sql]: [string]) => sql);
+    expect(calls).toContain("ROLLBACK");
+    expect(mockClient.release).toHaveBeenCalled();
   });
 });
 

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -90,8 +90,15 @@ const envSchema = z.object({
   /** HTTP port the Express server listens on. Default: 3001. */
   PORT: portString(3001),
 
+  // ── Indexer ─────────────────────────────────────────────────────────────────
   /** Set to "false" to disable the on-chain event indexer. Default: true. */
   ENABLE_INDEXER: booleanString(true),
+
+  /**
+   * Ledger sequence number to start indexing from on a cold start (no saved checkpoint).
+   * Set to a recent ledger to skip historical replay. Default: 1 (full history).
+   */
+  START_LEDGER: z.string().default("1").transform(Number).pipe(z.number().int().min(1)),
 
   // ── Rate Limiting ────────────────────────────────────────────────────────────
   /** Sliding window duration in milliseconds. Default: 60000 (1 min). */

--- a/backend/src/indexer/indexer.ts
+++ b/backend/src/indexer/indexer.ts
@@ -38,6 +38,10 @@ const BACKOFF_MULTIPLIER = 2;
 const JITTER_FACTOR      = 0.2;     // ±20% random jitter
 const MAX_EVENT_RETRIES  = 3;       // per-event retries before dead-letter
 
+// Ledger to start from on a cold start (no saved checkpoint).
+// Configurable via START_LEDGER env var so operators can skip historical replay.
+const START_LEDGER = env.START_LEDGER ?? 1;
+
 // ── Backoff state (module-level so tests can inspect/reset) ───────────────────
 
 export let currentBackoffMs = 0;    // 0 = no active backoff
@@ -59,6 +63,18 @@ export async function getCursor(): Promise<string | undefined> {
 }
 
 /**
+ * Reads the last processed ledger sequence number from `indexer_state`.
+ *
+ * @returns The last saved ledger number, or `undefined` on a cold start.
+ */
+export async function getLastLedger(): Promise<number | undefined> {
+  const { rows } = await pool.query<{ value: string }>(
+    `SELECT value FROM indexer_state WHERE key = 'last_ledger' LIMIT 1`
+  );
+  return rows[0] ? parseInt(rows[0].value, 10) : undefined;
+}
+
+/**
  * Persists the Soroban RPC paging token so the next poll continues after this event.
  *
  * @param cursor - Paging token from the last event in a successfully polled batch.
@@ -71,6 +87,39 @@ export async function saveCursor(cursor: string): Promise<void> {
      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
     [cursor]
   );
+}
+
+/**
+ * Atomically persists the paging cursor and last processed ledger in a single transaction.
+ * This ensures the checkpoint is always consistent: a crash mid-batch will not leave
+ * the cursor advanced past the last committed ledger.
+ *
+ * @param cursor - Paging token from the last event in the batch.
+ * @param ledger - Ledger sequence number of the last processed event.
+ * @returns Resolves when both rows are committed.
+ * @throws Re-throws any database error after rolling back.
+ */
+export async function saveCheckpoint(cursor: string, ledger: number): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `INSERT INTO indexer_state (key, value) VALUES ('cursor', $1)
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+      [cursor]
+    );
+    await client.query(
+      `INSERT INTO indexer_state (key, value) VALUES ('last_ledger', $1)
+       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value`,
+      [String(ledger)]
+    );
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
 }
 
 /** Persist a failed event to the dead_letter_events table for later inspection. */
@@ -290,14 +339,15 @@ async function poll(): Promise<void> {
     ];
 
     // Ledger cursor strategy:
-    // - Cold start (no saved paging token): set startLedger to 1 so the RPC scans from
-    //   the beginning of chain history for the filtered contracts.
+    // - Cold start (no saved paging token): set startLedger to START_LEDGER env var
+    //   (defaults to 1 for full history; set to a recent ledger to skip replay).
     // - Warm start: pass the persisted paging token as `cursor` so each poll fetches only
     //   events after the last committed position—no gaps and no full-chain replay.
-    // - After a non-empty batch: save the final event's pagingToken; a crash mid-batch may
-    //   re-deliver some events, which is safe because service upserts are idempotent.
+    // - After a non-empty batch: atomically save the final event's pagingToken and ledger
+    //   in one transaction; a crash mid-batch may re-deliver some events, which is safe
+    //   because service upserts are idempotent.
     const result = await rpcServer.getEvents({
-      startLedger: cursor ? undefined : 1,
+      startLedger: cursor ? undefined : START_LEDGER,
       cursor,
       filters,
       limit: 100,
@@ -309,11 +359,11 @@ async function poll(): Promise<void> {
       indexerEventsTotal.inc();
     }
 
-    // Persist cursor after the batch so a crash mid-batch re-processes
-    // (idempotent upserts in the service layer handle duplicates safely)
+    // Atomically persist cursor and last ledger after the batch so a crash mid-batch
+    // re-processes (idempotent upserts in the service layer handle duplicates safely).
     if (result.events.length > 0) {
       const last = result.events[result.events.length - 1] as unknown as SorobanRpc.Api.RawEventResponse;
-      await saveCursor(last.pagingToken);
+      await saveCheckpoint(last.pagingToken, Number(last.ledger));
     }
 
     // Update lag metric


### PR DESCRIPTION
- indexer_state table stores both cursor (paging token) and last_ledger
- saveCheckpoint() atomically persists cursor + ledger in one transaction
- On cold start, indexer reads from START_LEDGER env var (default: 1)
- On warm start, resumes from saved paging token — no full-chain replay
- getLastLedger() reads persisted ledger number from indexer_state
- START_LEDGER added to env schema and .env.example
- Tests added for getLastLedger, saveCheckpoint (transaction + rollback)

Closes #328
