### PR TITLE
feat(backend): add reusable Stellar address format validator

### DIFF
--- a/backend/src/__tests__/stellar-address-validation.test.ts
+++ b/backend/src/__tests__/stellar-address-validation.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Unit tests for Stellar address validation utility.
+ * Covers isValidStellarAddress and assertStellarAddress.
+ */
+
+import { isValidStellarAddress, assertStellarAddress } from "../utils/validation";
+import { BadRequestError } from "../utils/errors";
+
+// A real-looking 56-char Stellar address (G + 55 base32 chars)
+const VALID_ADDRESS = "GCKFBEIYTKP5RDBQMTVVALONAOPBXICILMAFKKWOHHJJD42YSWDYD2QC";
+
+describe("isValidStellarAddress", () => {
+  it("returns true for a valid Stellar address", () => {
+    expect(isValidStellarAddress(VALID_ADDRESS)).toBe(true);
+  });
+
+  it("returns false when address does not start with G", () => {
+    expect(isValidStellarAddress("ACKFBEIYTKP5RDBQMTVVALONAOPBXICILMAFKKWOHHJJD42YSWDYD2QC")).toBe(false);
+  });
+
+  it("returns false when address is shorter than 56 characters", () => {
+    expect(isValidStellarAddress("GCKFBEIYTKP5RDBQMTVVALONAOPBXICILMAFKKWOHHJJD42YSWDYD2Q")).toBe(false);
+  });
+
+  it("returns false when address is longer than 56 characters", () => {
+    expect(isValidStellarAddress(VALID_ADDRESS + "X")).toBe(false);
+  });
+
+  it("returns false for an empty string", () => {
+    expect(isValidStellarAddress("")).toBe(false);
+  });
+
+  it("returns false when address contains lowercase letters", () => {
+    expect(isValidStellarAddress("gCKFBEIYTKP5RDBQMTVVALONAOPBXICILMAFKKWOHHJJD42YSWDYD2QC")).toBe(false);
+  });
+
+  it("returns false when address contains invalid base32 characters (e.g. 0, 1, 8, 9)", () => {
+    // Replace a valid char with '0' which is not in base32 alphabet
+    const invalid = "G0KFBEIYTKP5RDBQMTVVALONAOPBXICILMAFKKWOHHJJD42YSWDYD2QC";
+    expect(isValidStellarAddress(invalid)).toBe(false);
+  });
+
+  it("returns false for a random string", () => {
+    expect(isValidStellarAddress("not-a-stellar-address")).toBe(false);
+  });
+});
+
+describe("assertStellarAddress", () => {
+  it("does not throw for a valid address", () => {
+    expect(() => assertStellarAddress(VALID_ADDRESS)).not.toThrow();
+  });
+
+  it("throws BadRequestError for an invalid address", () => {
+    expect(() => assertStellarAddress("invalid")).toThrow(BadRequestError);
+  });
+
+  it("includes the field name in the error details", () => {
+    try {
+      assertStellarAddress("invalid", "owner");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BadRequestError);
+      expect((err as BadRequestError).details).toHaveProperty("owner");
+    }
+  });
+
+  it("throws with HTTP 400 status code", () => {
+    try {
+      assertStellarAddress("tooshort");
+    } catch (err) {
+      expect((err as BadRequestError).statusCode).toBe(400);
+    }
+  });
+});

--- a/backend/src/routes/reward.routes.ts
+++ b/backend/src/routes/reward.routes.ts
@@ -6,6 +6,7 @@ import { validateBody, validateParams } from "../middleware/validation";
 import { BadRequestError } from "../utils/errors";
 import { isValidStellarAddress } from "../utils/validation";
 import { rewardsLimiter } from "../middleware/rateLimiter";
+import { StellarAddressParamSchema } from "./schemas";
 
 export const rewardRouter = Router();
 
@@ -48,11 +49,8 @@ const ClaimSchema = z.object({
  *       500:
  *         description: Server error.
  */
-rewardRouter.get("/user/:address/rewards", rewardsLimiter, asyncHandler(async (req: Request, res: Response) => {
+rewardRouter.get("/user/:address/rewards", rewardsLimiter, validateParams(StellarAddressParamSchema), asyncHandler(async (req: Request, res: Response) => {
   const address = String(req.params.address);
-  if (!isValidStellarAddress(address)) {
-    throw new BadRequestError("Invalid Stellar address", { address });
-  }
   try {
     const rewards = await getRewardsByUser(address);
     res.json({ rewards });
@@ -65,11 +63,8 @@ rewardRouter.get("/user/:address/rewards", rewardsLimiter, asyncHandler(async (r
  * POST /user/:address/rewards/claim
  * Inserts a reward claim once per (user, campaign). Duplicate claims return 409.
  */
-rewardRouter.post("/user/:address/rewards/claim", asyncHandler(async (req: Request, res: Response) => {
+rewardRouter.post("/user/:address/rewards/claim", validateParams(StellarAddressParamSchema), asyncHandler(async (req: Request, res: Response) => {
   const address = String(req.params.address);
-  if (!isValidStellarAddress(address)) {
-    throw new BadRequestError("Invalid Stellar address", { address });
-  }
 
   const parsed = ClaimSchema.safeParse(req.body);
   if (!parsed.success) {

--- a/backend/src/routes/schemas.ts
+++ b/backend/src/routes/schemas.ts
@@ -1,8 +1,28 @@
 import { z } from "zod";
+import { isValidStellarAddress } from "../utils/validation";
 
 /**
  * Common validation schemas used across multiple routes
  */
+
+/** Validates a Stellar public key: starts with G, exactly 56 base32 characters. */
+export const StellarAddressParamSchema = z.object({
+  address: z
+    .string()
+    .refine(isValidStellarAddress, {
+      message: "Invalid Stellar address: must start with G and be exactly 56 characters",
+    }),
+});
+
+/** Validates a Stellar address in a query string field named 'address'. */
+export const StellarAddressQuerySchema = z.object({
+  address: z
+    .string()
+    .refine(isValidStellarAddress, {
+      message: "Invalid Stellar address: must start with G and be exactly 56 characters",
+    })
+    .optional(),
+});
 
 export const StellarAddressSchema = z.object({
   address: z.string().length(56, "Stellar address must be 56 characters")

--- a/backend/src/utils/validation.ts
+++ b/backend/src/utils/validation.ts
@@ -8,3 +8,18 @@ export function parseStrictInteger(value: string): number | null {
 export function isValidStellarAddress(address: string): boolean {
   return /^G[A-Z2-7]{55}$/.test(address);
 }
+
+/**
+ * Validates a Stellar address string.
+ * Throws BadRequestError with a descriptive message when invalid.
+ * Use this for route params and query strings that accept Stellar addresses.
+ */
+export function assertStellarAddress(address: string, fieldName = "address"): void {
+  if (!isValidStellarAddress(address)) {
+    const { BadRequestError } = require("./errors");
+    throw new BadRequestError(
+      `Invalid Stellar address for '${fieldName}': must start with G and be exactly 56 characters`,
+      { [fieldName]: address }
+    );
+  }
+}


### PR DESCRIPTION
- isValidStellarAddress: checks G prefix and 56-char base32 length
- assertStellarAddress: throws BadRequestError(400) with descriptive message
- StellarAddressParamSchema: reusable Zod schema for route params
- reward routes now use validateParams(StellarAddressParamSchema) instead of manual checks
- Invalid addresses in route params return HTTP 400 with descriptive error
- Unit tests cover valid/invalid address examples for both helpers

Closes #326
