### PR TITLE
Add confirmation modal before redeem (burn) action   #329

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.53.0](https://github.com/Dev-Odun-oss/Soroban-Loyalty/compare/v1.52.0...v1.53.0) (2026-06-01)
+
+
+### Features
+
+* **frontend:** add confirmation modal before redeem (burn) action ([3bd3210](https://github.com/Ndanusa/Soroban-Loyalty/commit/3bd32106)), closes [#329](https://github.com/Dev-Odun-oss/Soroban-Loyalty/issues/329)
+
 # [1.52.0](https://github.com/Dev-Odun-oss/Soroban-Loyalty/compare/v1.51.0...v1.52.0) (2026-05-31)
 
 

--- a/frontend/src/__tests__/RewardList.test.tsx
+++ b/frontend/src/__tests__/RewardList.test.tsx
@@ -49,43 +49,126 @@ describe("RewardList Component", () => {
     });
 
     test("shows redeemed status with amount", () => {
-      render(<RewardList rewards={[{ ...reward, redeemed: true, redeemed_amount: 100 }]} />);
+      render(
+        <RewardList
+          rewards={[{ ...reward, redeemed: true, redeemed_amount: 100 }]}
+        />
+      );
       expect(screen.getByText(/Redeemed 100 LYT/i)).toBeInTheDocument();
     });
 
     test("hides redeem button for redeemed rewards", () => {
-      render(<RewardList rewards={[{ ...reward, redeemed: true, redeemed_amount: 100 }]} />);
-      expect(screen.queryByRole("button", { name: /redeem/i })).not.toBeInTheDocument();
+      render(
+        <RewardList
+          rewards={[{ ...reward, redeemed: true, redeemed_amount: 100 }]}
+        />
+      );
+      expect(
+        screen.queryByRole("button", { name: /redeem/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Confirmation Modal", () => {
+    test("does NOT call onRedeem immediately when Redeem button is clicked", () => {
+      const onRedeem = jest.fn();
+      render(<RewardList rewards={[reward]} onRedeem={onRedeem} />);
+      fireEvent.click(screen.getByRole("button", { name: /redeem 100 lyt from campaign 1/i }));
+      expect(onRedeem).not.toHaveBeenCalled();
+    });
+
+    test("opens confirmation modal when Redeem button is clicked", () => {
+      render(<RewardList rewards={[reward]} onRedeem={() => {}} />);
+      fireEvent.click(screen.getByRole("button", { name: /redeem 100 lyt from campaign 1/i }));
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+      expect(screen.getByText(/Burn LYT tokens\?/i)).toBeInTheDocument();
+    });
+
+    test("modal displays the exact LYT amount to be burned", () => {
+      render(<RewardList rewards={[reward]} onRedeem={() => {}} />);
+      fireEvent.click(screen.getByRole("button", { name: /redeem 100 lyt from campaign 1/i }));
+      expect(screen.getByText(/100/)).toBeInTheDocument();
+    });
+
+    test("modal includes irreversibility warning", () => {
+      render(<RewardList rewards={[reward]} onRedeem={() => {}} />);
+      fireEvent.click(screen.getByRole("button", { name: /redeem 100 lyt from campaign 1/i }));
+      expect(screen.getByText(/irreversible/i)).toBeInTheDocument();
+    });
+
+    test("Cancel button closes modal without calling onRedeem", () => {
+      const onRedeem = jest.fn();
+      render(<RewardList rewards={[reward]} onRedeem={onRedeem} />);
+      fireEvent.click(screen.getByRole("button", { name: /redeem 100 lyt from campaign 1/i }));
+      fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(onRedeem).not.toHaveBeenCalled();
+    });
+
+    test("Confirm button calls onRedeem with the correct reward", () => {
+      const onRedeem = jest.fn();
+      render(<RewardList rewards={[reward]} onRedeem={onRedeem} />);
+      fireEvent.click(screen.getByRole("button", { name: /redeem 100 lyt from campaign 1/i }));
+      fireEvent.click(screen.getByRole("button", { name: /confirm & burn/i }));
+      expect(onRedeem).toHaveBeenCalledWith(reward);
+    });
+
+    test("modal closes after confirm is clicked", () => {
+      render(<RewardList rewards={[reward]} onRedeem={jest.fn()} />);
+      fireEvent.click(screen.getByRole("button", { name: /redeem 100 lyt from campaign 1/i }));
+      fireEvent.click(screen.getByRole("button", { name: /confirm & burn/i }));
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    test("Escape key closes modal without calling onRedeem", () => {
+      const onRedeem = jest.fn();
+      render(<RewardList rewards={[reward]} onRedeem={onRedeem} />);
+      fireEvent.click(screen.getByRole("button", { name: /redeem 100 lyt from campaign 1/i }));
+      fireEvent.keyDown(document, { key: "Escape", code: "Escape" });
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+      expect(onRedeem).not.toHaveBeenCalled();
     });
   });
 
   describe("Claim Button Interaction", () => {
     test("renders redeem button for unredeemed rewards", () => {
       render(<RewardList rewards={[reward]} onRedeem={() => {}} />);
-      expect(screen.getByRole("button", { name: /redeem/i })).toBeInTheDocument();
-    });
-
-    test("triggers onClaim callback with correct reward ID", () => {
-      const onRedeem = jest.fn();
-      render(<RewardList rewards={[reward]} onRedeem={onRedeem} />);
-      const button = screen.getByRole("button", { name: /redeem/i });
-      fireEvent.click(button);
-      expect(onRedeem).toHaveBeenCalledWith(reward);
+      expect(
+        screen.getByRole("button", { name: /redeem/i })
+      ).toBeInTheDocument();
     });
 
     test("disables redeem button when redeeming", () => {
-      render(<RewardList rewards={[reward]} onRedeem={() => {}} redeemStatus={{ [reward.id]: 'loading' }} />);
+      render(
+        <RewardList
+          rewards={[reward]}
+          onRedeem={() => {}}
+          redeemStatus={{ [reward.id]: "loading" }}
+        />
+      );
       const button = screen.getByRole("button", { name: /redeeming/i });
       expect(button).toBeDisabled();
     });
 
     test("shows redeeming state text", () => {
-      render(<RewardList rewards={[reward]} onRedeem={() => {}} redeemStatus={{ [reward.id]: 'loading' }} />);
+      render(
+        <RewardList
+          rewards={[reward]}
+          onRedeem={() => {}}
+          redeemStatus={{ [reward.id]: "loading" }}
+        />
+      );
       expect(screen.getByText(/Redeeming/i)).toBeInTheDocument();
     });
 
     test("shows success state text when redeem succeeded", () => {
-      render(<RewardList rewards={[reward]} onRedeem={() => {}} redeemStatus={{ [reward.id]: 'success' }} />);
+      render(
+        <RewardList
+          rewards={[reward]}
+          onRedeem={() => {}}
+          redeemStatus={{ [reward.id]: "success" }}
+        />
+      );
       expect(screen.getByText(/Redeemed!/i)).toBeInTheDocument();
     });
 
@@ -94,12 +177,14 @@ describe("RewardList Component", () => {
         <RewardList
           rewards={[reward]}
           onRedeem={() => {}}
-          redeemStatus={{ [reward.id]: 'error' }}
-          redeemMessage={{ [reward.id]: 'Insufficient balance' }}
+          redeemStatus={{ [reward.id]: "error" }}
+          redeemMessage={{ [reward.id]: "Insufficient balance" }}
         />
       );
       expect(screen.getByText(/Insufficient balance/i)).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /Insufficient balance/i })).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /Insufficient balance/i })
+      ).not.toBeDisabled();
     });
 
     test("does not disable button for other rewards while redeeming", () => {
@@ -108,7 +193,7 @@ describe("RewardList Component", () => {
         <RewardList
           rewards={[reward, r2]}
           onRedeem={() => {}}
-          redeemStatus={{ [reward.id]: 'loading' }}
+          redeemStatus={{ [reward.id]: "loading" }}
         />
       );
       const buttons = screen.getAllByRole("button", { name: /redeem/i });
@@ -118,7 +203,9 @@ describe("RewardList Component", () => {
 
     test("has accessible aria-label on redeem button", () => {
       render(<RewardList rewards={[reward]} onRedeem={() => {}} />);
-      const button = screen.getByRole("button", { name: /redeem 100 lyt from campaign 1/i });
+      const button = screen.getByRole("button", {
+        name: /redeem 100 lyt from campaign 1/i,
+      });
       expect(button).toBeInTheDocument();
     });
   });
@@ -138,7 +225,13 @@ describe("RewardList Component", () => {
     test("handles mixed redeemed and unredeemed rewards", () => {
       const rewards = [
         reward,
-        { ...reward, id: "r2", campaign_id: 2, redeemed: true, redeemed_amount: 100 },
+        {
+          ...reward,
+          id: "r2",
+          campaign_id: 2,
+          redeemed: true,
+          redeemed_amount: 100,
+        },
       ];
       render(<RewardList rewards={rewards} onRedeem={() => {}} />);
       expect(screen.getByText(/Available/i)).toBeInTheDocument();

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -28,13 +28,18 @@ export default function DashboardPage() {
   const [loadingCampaigns, setLoadingCampaigns] = useState(false);
   const [rewards, setRewards] = useState<Reward[]>([]);
   const [rewardError, setRewardError] = useState<string | null>(null);
-  const [redeemingId, setRedeemingId] = useState<string | null>(null);
-  const [optimisticClaimed, setOptimisticClaimed] = useState<Set<number>>(new Set());
+  const [redeemStatus, setRedeemStatus] = useState<
+    Record<string, "idle" | "loading" | "success" | "error">
+  >({});
+  const [redeemMessage, setRedeemMessage] = useState<Record<string, string>>(
+    {}
+  );
+  const [optimisticClaimed, setOptimisticClaimed] = useState<Set<number>>(
+    new Set()
+  );
   const [offset, setOffset] = useState(0);
   const [total, setTotal] = useState<number | null>(null);
-  const [loadingCampaigns, setLoadingCampaigns] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [loadingCampaigns, setLoadingCampaigns] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   const networkDisabled = health.status === "unreachable";
@@ -46,11 +51,15 @@ export default function DashboardPage() {
       setCampaignError(null);
       try {
         const response = await api.getCampaigns(PAGE_SIZE, nextOffset);
-        setCampaigns((prev) => (replace ? response.campaigns : [...prev, ...response.campaigns]));
+        setCampaigns((prev) =>
+          replace ? response.campaigns : [...prev, ...response.campaigns]
+        );
         setOffset(nextOffset + response.campaigns.length);
         setTotal(response.total);
       } catch (err) {
-        setCampaignError(err instanceof Error ? err.message : "Failed to load campaigns");
+        setCampaignError(
+          err instanceof Error ? err.message : "Failed to load campaigns"
+        );
       } finally {
         setLoadingMore(false);
         if (replace) setLoadingCampaigns(false);
@@ -65,10 +74,14 @@ export default function DashboardPage() {
     try {
       const r = await api.getUserRewards(publicKey);
       setRewards(r.data);
-      const claimedIds = r.data.filter((rw) => !rw.redeemed).map((rw) => rw.campaign_id);
+      const claimedIds = r.data
+        .filter((rw) => !rw.redeemed)
+        .map((rw) => rw.campaign_id);
       setOptimisticClaimed(new Set(claimedIds));
     } catch (err) {
-      setRewardError(err instanceof Error ? err.message : "Failed to load rewards");
+      setRewardError(
+        err instanceof Error ? err.message : "Failed to load rewards"
+      );
     }
   }, [publicKey]);
 
@@ -87,7 +100,12 @@ export default function DashboardPage() {
     if (!sentinel) return;
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0].isIntersecting && !loadingMore && total !== null && offset < total) {
+        if (
+          entries[0].isIntersecting &&
+          !loadingMore &&
+          total !== null &&
+          offset < total
+        ) {
           loadCampaigns(offset);
         }
       },
@@ -109,7 +127,10 @@ export default function DashboardPage() {
     try {
       await claimReward(publicKey, campaignId);
     } catch (err: unknown) {
-      toast(err instanceof Error ? err.message : t("messages.claimFailed"), "error");
+      toast(
+        err instanceof Error ? err.message : t("messages.claimFailed"),
+        "error"
+      );
       throw err;
     }
     setOptimisticClaimed((prev) => new Set(prev).add(campaignId));
@@ -119,7 +140,11 @@ export default function DashboardPage() {
     await refreshBalance();
   };
 
-  const handleRedeem = async (rewardId: string, amount: number) => {
+  /**
+   * Called after the user has confirmed the redeem action in the modal.
+   * Accepts the full Reward object so the list can show per-item status.
+   */
+  const handleRedeem = async (reward: Reward) => {
     if (!publicKey) {
       toast("Please connect your wallet first", "error");
       return;
@@ -129,12 +154,15 @@ export default function DashboardPage() {
       return;
     }
 
+    const rewardId = reward.id;
     setRedeemStatus((prev) => ({ ...prev, [rewardId]: "loading" }));
     setRedeemMessage((prev) => ({ ...prev, [rewardId]: "" }));
 
     try {
-      await redeemReward(publicKey, BigInt(amount));
-      const successMessage = t("messages.redeemSuccess", { amount: amount.toString() });
+      await redeemReward(publicKey, BigInt(reward.amount));
+      const successMessage = t("messages.redeemSuccess", {
+        amount: reward.amount.toString(),
+      });
       setRedeemStatus((prev) => ({ ...prev, [rewardId]: "success" }));
       setRedeemMessage((prev) => ({ ...prev, [rewardId]: successMessage }));
       toast(successMessage, "success");
@@ -142,7 +170,8 @@ export default function DashboardPage() {
       setRewards(r.data);
       await refreshBalance();
     } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : t("messages.redeemFailed");
+      const errorMessage =
+        err instanceof Error ? err.message : t("messages.redeemFailed");
       setRedeemStatus((prev) => ({ ...prev, [rewardId]: "error" }));
       setRedeemMessage((prev) => ({ ...prev, [rewardId]: errorMessage }));
       toast(errorMessage, "error");
@@ -162,48 +191,66 @@ export default function DashboardPage() {
         <NetworkBanner />
 
         <section style={{ marginBottom: "2rem" }}>
-        <h1 className="page-title">Active Campaigns</h1>
-        {campaignError ? (
-          <ErrorState message={campaignError} onRetry={() => loadCampaigns(0, true)} />
-        ) : campaigns.length === 0 && !loadingMore ? (
-          <EmptyState
-            illustration="campaigns"
-            title="No active campaigns"
-            description="Check back later for new loyalty campaigns."
-          />
-        ) : (
-          <div className="campaign-grid">
-            {campaigns.map((campaign) => (
-              <CampaignCard
-                key={campaign.id}
-                campaign={campaign}
-                isClaimed={optimisticClaimed.has(campaign.id)}
-                onClaim={() => handleClaim(campaign.id)}
-                disabled={networkDisabled}
-              />
-            ))}
+          <h1 className="page-title">Active Campaigns</h1>
+          {campaignError ? (
+            <ErrorState
+              message={campaignError}
+              onRetry={() => loadCampaigns(0, true)}
+            />
+          ) : campaigns.length === 0 && !loadingMore ? (
+            <EmptyState
+              illustration="campaigns"
+              title="No active campaigns"
+              description="Check back later for new loyalty campaigns."
+            />
+          ) : (
+            <div className="campaign-grid">
+              {campaigns.map((campaign) => (
+                <CampaignCard
+                  key={campaign.id}
+                  campaign={campaign}
+                  isClaimed={optimisticClaimed.has(campaign.id)}
+                  onClaim={() => handleClaim(campaign.id)}
+                  disabled={networkDisabled}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section style={{ marginTop: 40 }}>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              marginBottom: "16px",
+            }}
+          >
+            <h2 className="section-title" style={{ marginBottom: 0 }}>
+              {t("rewards.title")}
+            </h2>
+            <Link
+              href="/dashboard/history"
+              className="btn btn-outline"
+              style={{ fontSize: "0.8rem", padding: "4px 12px" }}
+            >
+              View History
+            </Link>
           </div>
+          <RewardList
+            rewards={rewards}
+            onRedeem={networkDisabled ? undefined : handleRedeem}
+            redeemStatus={redeemStatus}
+            redeemMessage={redeemMessage}
+            error={rewardError}
+            onRetry={loadRewards}
+          />
+        </section>
+
+        {hasMore && (
+          <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />
         )}
-      </section>
-
-      <section style={{ marginTop: 40 }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: "16px" }}>
-          <h2 className="section-title" style={{ marginBottom: 0 }}>{t("rewards.title")}</h2>
-          <Link href="/dashboard/history" className="btn btn-outline" style={{ fontSize: "0.8rem", padding: "4px 12px" }}>
-            View History
-          </Link>
-        </div>
-        <RewardList
-          rewards={rewards}
-          onRedeem={networkDisabled ? undefined : handleRedeem}
-          redeemStatus={redeemStatus}
-          redeemMessage={redeemMessage}
-          error={rewardError}
-          onRetry={loadRewards}
-        />
-      </section>
-
-      {hasMore && <div ref={sentinelRef} style={{ height: 1 }} aria-hidden="true" />}
       </div>
     </WalletGuard>
   );

--- a/frontend/src/components/RewardList.tsx
+++ b/frontend/src/components/RewardList.tsx
@@ -1,39 +1,23 @@
 /**
  * RewardList Component
- * 
+ *
  * Displays a list of rewards claimed by the user. Shows reward amount, claim date,
  * redemption status, and a redeem button for unredeemed rewards.
- * 
+ *
+ * Clicking "Redeem" opens a confirmation modal explaining that the action will
+ * permanently burn the LYT tokens and cannot be undone. Only after the user
+ * clicks "Confirm & Burn" in the modal is the actual onRedeem callback invoked.
+ *
  * @example
  * ```tsx
  * import { RewardList } from '@/components/RewardList';
- * 
+ *
  * export function RewardsPage({ rewards }) {
- *   const [redeemStatus, setRedeemStatus] = useState<Record<string, 'idle' | 'loading' | 'success' | 'error'>>({});
- *   const [redeemMessage, setRedeemMessage] = useState<Record<string, string>>({});
- *   
- *   const handleRedeem = async (reward: Reward) => {
- *     setRedeemStatus((prev) => ({ ...prev, [reward.id]: 'loading' }));
- *     try {
- *       await redeemReward(reward.id);
- *       setRedeemStatus((prev) => ({ ...prev, [reward.id]: 'success' }));
- *     } catch (err) {
- *       setRedeemStatus((prev) => ({ ...prev, [reward.id]: 'error' }));
- *       setRedeemMessage((prev) => ({ ...prev, [reward.id]: err.message }));
- *     }
- *   };
- *   
- *   return (
- *     <RewardList
- *       rewards={rewards}
- *       onRedeem={handleRedeem}
- *       redeemStatus={redeemStatus}
- *       redeemMessage={redeemMessage}
- *     />
- *   );
+ *   const handleRedeem = async (reward: Reward) => { ... };
+ *   return <RewardList rewards={rewards} onRedeem={handleRedeem} />;
  * }
  * ```
- * 
+ *
  * @component
  * @param {RewardListProps} props
  * @returns {JSX.Element} List of rewards or empty state
@@ -41,32 +25,48 @@
 
 "use client";
 
+import { useState } from "react";
 import { Reward } from "@/lib/api";
 import { useI18n } from "@/context/I18nContext";
 import { EmptyState } from "@/components/EmptyState";
 import { ErrorState } from "@/components/ErrorState";
+import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 /**
  * Props for RewardList component
- * 
+ *
  * @typedef {Object} RewardListProps
  * @property {Reward[]} rewards - Array of reward objects to display
- * @property {(reward: Reward) => void} [onRedeem] - Callback when user clicks redeem button
- * @property {string | null} [redeeming] - ID of reward currently being redeemed (disables button)
+ * @property {(reward: Reward) => void} [onRedeem] - Callback invoked after user confirms the redeem action
+ * @property {Record<string, 'idle' | 'loading' | 'success' | 'error'>} [redeemStatus] - Per-reward status map
+ * @property {Record<string, string>} [redeemMessage] - Per-reward message map for success / error copy
  * @property {string | null} [error] - Error message to display instead of the list
  * @property {() => void} [onRetry] - Callback to retry the failed fetch
  */
 interface Props {
   rewards: Reward[];
   onRedeem?: (reward: Reward) => void;
-  redeemStatus?: Record<string, 'idle' | 'loading' | 'success' | 'error'>;
+  redeemStatus?: Record<string, "idle" | "loading" | "success" | "error">;
   redeemMessage?: Record<string, string>;
   error?: string | null;
   onRetry?: () => void;
 }
 
-export function RewardList({ rewards, onRedeem, redeemStatus = {}, redeemMessage = {}, error, onRetry }: Props) {
+export function RewardList({
+  rewards,
+  onRedeem,
+  redeemStatus = {},
+  redeemMessage = {},
+  error,
+  onRetry,
+}: Props) {
   const { t } = useI18n();
+
+  /**
+   * The reward currently awaiting user confirmation.
+   * null means the modal is closed.
+   */
+  const [pendingReward, setPendingReward] = useState<Reward | null>(null);
 
   if (error) {
     return <ErrorState message={error} onRetry={onRetry ?? (() => {})} />;
@@ -76,52 +76,108 @@ export function RewardList({ rewards, onRedeem, redeemStatus = {}, redeemMessage
     return (
       <EmptyState
         illustration="rewards"
-        title={t('rewards.noRewards')}
+        title={t("rewards.noRewards")}
         description="Complete a campaign to earn LYT tokens."
         cta={{ label: "Claim your first reward", href: "/campaigns" }}
       />
     );
   }
 
-  return (
-    <ul className="reward-list">
-      {rewards.map((r) => (
-        <li key={r.id} className="reward-item">
-          <div>
-            <strong>{t('campaigns.details.campaign')} #{r.campaign_id}</strong>
-            <span className="reward-amount">{r.amount.toLocaleString()} LYT</span>
-          </div>
-          <div className="reward-meta">
-            <span>{r.redeemed ? t('rewards.redeemed', { amount: r.redeemed_amount.toString() }) : t('rewards.available')}</span>
-            <span>{new Date(r.claimed_at).toLocaleDateString()}</span>
-          </div>
-          {onRedeem && !r.redeemed && (() => {
-            const status = redeemStatus[r.id] ?? 'idle';
-            const isLoading = status === 'loading';
-            const isSuccess = status === 'success';
-            const isError = status === 'error';
-            const buttonText = isLoading
-              ? t('rewards.actions.redeeming')
-              : isSuccess
-              ? t('rewards.actions.redeemed')
-              : isError
-              ? redeemMessage[r.id] || t('messages.redeemFailed')
-              : t('rewards.actions.redeem');
+  const handleRedeemClick = (reward: Reward) => {
+    setPendingReward(reward);
+  };
 
-            return (
-              <button
-                onClick={() => onRedeem(r)}
-                disabled={isLoading || isSuccess}
-                className="btn btn-secondary"
-                aria-label={`Redeem ${r.amount} LYT from campaign ${r.campaign_id}`}
-              >
-                {isLoading && <span className="inline-spinner" aria-hidden="true" style={{ marginRight: 8 }} />}
-                {buttonText}
-              </button>
-            );
-          })()}
-        </li>
-      ))}
-    </ul>
+  const handleConfirm = () => {
+    if (pendingReward && onRedeem) {
+      onRedeem(pendingReward);
+    }
+    setPendingReward(null);
+  };
+
+  const handleCancel = () => {
+    setPendingReward(null);
+  };
+
+  const isConfirming = (rewardId: string) =>
+    pendingReward?.id === rewardId &&
+    (redeemStatus[rewardId] ?? "idle") !== "loading";
+
+  return (
+    <>
+      <ul className="reward-list">
+        {rewards.map((r) => {
+          const status = redeemStatus[r.id] ?? "idle";
+          const isLoading = status === "loading";
+          const isSuccess = status === "success";
+          const isError = status === "error";
+          const buttonText = isLoading
+            ? t("rewards.actions.redeeming")
+            : isSuccess
+            ? t("rewards.actions.redeemed")
+            : isError
+            ? redeemMessage[r.id] || t("messages.redeemFailed")
+            : t("rewards.actions.redeem");
+
+          return (
+            <li key={r.id} className="reward-item">
+              <div>
+                <strong>
+                  {t("campaigns.details.campaign")} #{r.campaign_id}
+                </strong>
+                <span className="reward-amount">
+                  {r.amount.toLocaleString()} LYT
+                </span>
+              </div>
+              <div className="reward-meta">
+                <span>
+                  {r.redeemed
+                    ? t("rewards.redeemed", {
+                        amount: r.redeemed_amount.toString(),
+                      })
+                    : t("rewards.available")}
+                </span>
+                <span>{new Date(r.claimed_at).toLocaleDateString()}</span>
+              </div>
+              {onRedeem && !r.redeemed && (
+                <button
+                  onClick={() => handleRedeemClick(r)}
+                  disabled={isLoading || isSuccess || isConfirming(r.id)}
+                  className="btn btn-secondary"
+                  aria-label={`Redeem ${r.amount} LYT from campaign ${r.campaign_id}`}
+                >
+                  {isLoading && (
+                    <span
+                      className="inline-spinner"
+                      aria-hidden="true"
+                      style={{ marginRight: 8 }}
+                    />
+                  )}
+                  {buttonText}
+                </button>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      {/* Confirmation modal – shown when user clicks Redeem on a reward item */}
+      <ConfirmDialog
+        open={pendingReward !== null}
+        title="Burn LYT tokens?"
+        description={
+          pendingReward
+            ? `You are about to permanently burn ${pendingReward.amount.toLocaleString()} LYT from Campaign #${pendingReward.campaign_id}. This action is irreversible and cannot be undone.`
+            : ""
+        }
+        confirmLabel="Confirm & Burn"
+        cancelLabel="Cancel"
+        loading={
+          pendingReward !== null &&
+          redeemStatus[pendingReward.id] === "loading"
+        }
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    </>
   );
 }


### PR DESCRIPTION
- Wrap every Redeem button in RewardList with a ConfirmDialog modal
- Modal shows exact LYT amount to be burned and irreversibility warning
- Confirm & Burn button triggers onRedeem; Cancel closes without side effects
- Escape key dismisses the modal (WCAG 2.1 AA)
- Update dashboard/page.tsx: remove duplicate useState declarations and align handleRedeem signature to accept Reward object
- Expand RewardList tests: 9 new cases covering modal open/close, amount display, irreversibility copy, Cancel no-op, Confirm callback, Escape key

Closes #329 

## Pull Request Checklist

Before submitting your PR, please review the following checklist:

- [x] I have run tests locally and they all pass.
- [x] My code follows the project's coding style and guidelines.
- [x] I have added appropriate tests for new features or bug fixes.
- [ ] **Smart Contract Changes**: If I modified anything under `contracts/`, I updated `docs/audits/smart-contract-audit-status.yml` to reflect whether a re-audit is now required.
- [ ] **Database Schema Changes**: If I altered `schema.sql`, I have:
  - [ ] Updated the ERD (`docs/erd.png`).
  - [ ] Updated the schema documentation in `docs/database.md`.
- [ ] Runbook / Operations documentation is updated if necessary.
- [x] **Changelog & Versioning**:
  - [x] I have updated the `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/) format.
  - [x] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `BREAKING CHANGE:`).

---

> **Note:** No smart contract, database schema, or runbook changes were made in this PR — those checklist items do not apply.

### Files changed

| File | Description |
|---|---|
| [`https://github.com/Dev-Odun-oss/Soroban-Loyalty/frontend/src/components/RewardList.tsx`](frontend/src/components/RewardList.tsx) | Added `pendingReward` state + `ConfirmDialog`; Redeem button now opens modal |
| [`https://github.com/Dev-Odun-oss/Soroban-Loyalty/frontend/src/app/dashboard/page.tsx`](frontend/src/app/dashboard/page.tsx) | Removed duplicate `useState` declarations; aligned `handleRedeem` to accept `Reward` |
| [`https://github.com/Dev-Odun-oss/Soroban-Loyalty/frontend/src/__tests__/RewardList.test.tsx`](frontend/src/__tests__/RewardList.test.tsx) | 9 new test cases covering all acceptance criteria |

--- 
Closes #324 
Closes #320 
Closes #321 
