### PR TITLE
fix(#291): implement Redis caching for GET /campaigns

### DIFF
--- a/backend/src/lib/redis.ts
+++ b/backend/src/lib/redis.ts
@@ -30,4 +30,12 @@ export const redisClient = {
   async setex(key: string, seconds: number, value: string): Promise<void> {
     await getRedis().setex(key, seconds, value);
   },
+
+  async keys(pattern: string): Promise<string[]> {
+    return getRedis().keys(pattern);
+  },
+
+  async del(...keys: string[]): Promise<void> {
+    if (keys.length > 0) await getRedis().del(...keys);
+  },
 };

--- a/backend/src/routes/campaign.routes.ts
+++ b/backend/src/routes/campaign.routes.ts
@@ -7,6 +7,7 @@ import {
   reorderCampaigns,
   softDeleteCampaign,
   restoreCampaign,
+  deactivateCampaign,
   CampaignFilters,
 } from "../services/campaign.service";
 import { redisClient } from "../lib/redis";
@@ -188,7 +189,7 @@ campaignRouter.get("/", asyncHandler(async (req: Request, res: Response) => {
   };
 
   try {
-    await redisClient.setex(cacheKey, 30, JSON.stringify(paginatedResponse));
+    await redisClient.setex(cacheKey, 60, JSON.stringify(paginatedResponse));
   } catch (err) {
     logger.error("Redis cache write error", err as Error);
   }
@@ -364,5 +365,14 @@ campaignRouter.post("/", requireAuth, sanitizeBody, validateBody(CreateCampaignS
     total_claimed: 0,
     owner_address: ownerAddress,
   });
+
+  // Invalidate all campaign list cache keys
+  try {
+    const keys = await redisClient.keys("campaigns:list:*");
+    if (keys.length > 0) await redisClient.del(...keys);
+  } catch (err) {
+    logger.error("Redis cache invalidation error", err as Error);
+  }
+
   res.status(201).json({ ok: true });
 }));


### PR DESCRIPTION
Summary
  │ The Redis caching implementation for GET /campaigns was partially wired but had three bugs: wrong TTL, missing
  keys()/del() methods on redisClient, and no cache invalidation on campaign creation.
  │ 
  │ Changes
  │ - Fixed cache TTL from 30s → 60s to match the spec.
  │ - Added keys() and del() to redisClient — these were already being called in the PATCH route but were undefined,
  silently breaking cache invalidation on update.
  │ - Added cache invalidation to POST /campaigns so creating a campaign busts the list cache.
  │ - Fixed missing deactivateCampaign import that would have caused a runtime crash on PATCH /:id.
  │ 
  │ Tested
  │ Cache hit skips DB query. Cache is invalidated on create and update. Redis unavailability falls back to DB without
  error (errors are caught and logged).

closes #291 