### PR TITLE
fix(#292): make campaign grid responsive for mobile viewports

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -429,29 +429,28 @@ body {
   .empty-state-container { padding: 32px 16px; }
 }
 /* ── Responsive Grid ──────────────────────────────────────────────────────── */
-.grid {
+.grid,
+.campaign-grid {
   display: grid;
   gap: 20px;
   width: 100%;
   max-width: 100%;
   overflow-x: hidden;
-}
-
-/* Mobile: Single column (< 640px) */
-.grid {
   grid-template-columns: 1fr;
 }
 
 /* Tablet: Two columns (640px - 1024px) */
 @media (min-width: 640px) {
-  .grid {
+  .grid,
+  .campaign-grid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
 /* Desktop: Three columns (> 1024px) */
 @media (min-width: 1024px) {
-  .grid {
+  .grid,
+  .campaign-grid {
     grid-template-columns: repeat(3, 1fr);
   }
 }


### PR DESCRIPTION
Summary
  │ The campaign grid on /campaigns used a .campaign-grid class that had no CSS definition — only .grid existed. This
  caused a fixed-width layout that broke on small screens.
  │ 
  │ Changes
  │ - Added .campaign-grid to globals.css with responsive breakpoints: 1-column below 640px, 2-column between
  640px–1024px, 3-column above 1024px.
  │ - No JavaScript changes — pure CSS Grid with media queries.
  │ 
  │ Tested
  │ Verified layout collapses correctly at each breakpoint. No horizontal scrollbar appears. CampaignCard content
  stays within bounds at all viewport sizes.

closes #292 