### PR TITLE
feat: add central TypeScript type definitions with JSDoc (#353)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,18 +159,41 @@ Test coverage:
 
 ## API Reference
 
+### TypeScript Types
+
+Shared types are documented in the central type definition files:
+
+| File | Types |
+|---|---|
+| `backend/src/types/index.ts` | `Campaign`, `CampaignFilters`, `Reward`, `TransactionRecord`, `AnalyticsData`, `CampaignAnalyticsData`, `AuditLogEntry`, `AuditAction`, `AuditLogFilters` |
+| `frontend/src/types/index.ts` | `Campaign`, `Reward`, `TransactionRecord`, `AnalyticsData` |
+
+Backend services re-export their types from `backend/src/types/index.ts`. Frontend components import types from `@/types` (or via the `@/lib/api` re-export for backwards compatibility).
+
 ### Campaigns
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/campaigns` | List all campaigns |
-| `GET` | `/campaigns/:id` | Get campaign by ID |
+| Method | Path | Description | Response type |
+|---|---|---|---|
+| `GET` | `/campaigns` | List all campaigns | `{ campaigns: Campaign[]; total: number }` |
+| `GET` | `/campaigns/:id` | Get campaign by ID | `{ campaign: Campaign }` |
 
 ### Rewards
 
-| Method | Path | Description |
-|---|---|---|
-| `GET` | `/user/:address/rewards` | Get all rewards for a user |
+| Method | Path | Description | Response type |
+|---|---|---|---|
+| `GET` | `/user/:address/rewards` | Get all rewards for a user | `{ data: Reward[]; total: number; limit: number; offset: number }` |
+
+### Transactions
+
+| Method | Path | Description | Response type |
+|---|---|---|---|
+| `GET` | `/user/:address/transactions` | Get indexed transactions for a user | `{ transactions: TransactionRecord[]; total: number }` |
+
+### Analytics
+
+| Method | Path | Description | Response type |
+|---|---|---|---|
+| `GET` | `/analytics?days=N` | Aggregated reward metrics | `AnalyticsData` |
 
 ### Health
 

--- a/backend/src/services/analytics.service.ts
+++ b/backend/src/services/analytics.service.ts
@@ -1,13 +1,8 @@
 import { pool } from "../db";
 import { redisClient } from "../lib/redis";
+import type { AnalyticsData, CampaignAnalyticsData } from "../types";
 
-export interface AnalyticsData {
-  totalClaims: number;
-  totalLYT: number;
-  redemptionRate: number;
-  claimsPerCampaign: { name: string; claims: number }[];
-  claimsOverTime: { date: string; claims: number }[];
-}
+export type { AnalyticsData, CampaignAnalyticsData };
 
 /**
  * Aggregates reward claim metrics for the merchant analytics dashboard.
@@ -67,13 +62,6 @@ export async function getAnalytics(days: number): Promise<AnalyticsData> {
       claims: parseInt(r.claims, 10),
     })),
   };
-}
-
-export interface CampaignAnalyticsData {
-  total_campaigns: number;
-  total_claims: number;
-  claims_per_day: { date: string; count: number }[];
-  top_campaigns: { campaign_id: number; claims: number }[];
 }
 
 const CACHE_KEY = "analytics:campaigns";

--- a/backend/src/services/audit.service.ts
+++ b/backend/src/services/audit.service.ts
@@ -1,21 +1,8 @@
 import { pool } from "../db";
 import { PoolClient } from "pg";
+import type { AuditAction, AuditLogEntry, AuditLogFilters } from "../types";
 
-export type AuditAction =
-  | "campaign.create"
-  | "campaign.deactivate"
-  | "reward.claim"
-  | "reward.redeem";
-
-export interface AuditLogEntry {
-  id: string;
-  actor: string;
-  action: AuditAction;
-  entity_type: string;
-  entity_id: string;
-  metadata: Record<string, unknown>;
-  created_at: Date;
-}
+export type { AuditAction, AuditLogEntry, AuditLogFilters };
 
 /**
  * Writes an audit log entry for a privileged or on-chain-derived action.
@@ -36,17 +23,6 @@ export async function writeAuditLog(
      VALUES ($1, $2, $3, $4, $5)`,
     [entry.actor, entry.action, entry.entity_type, entry.entity_id, JSON.stringify(entry.metadata)]
   );
-}
-
-export interface AuditLogFilters {
-  actor?: string;
-  action?: AuditAction;
-  entity_type?: string;
-  entity_id?: string;
-  since?: Date;
-  until?: Date;
-  limit?: number;
-  offset?: number;
 }
 
 /**

--- a/backend/src/services/campaign.service.ts
+++ b/backend/src/services/campaign.service.ts
@@ -1,21 +1,8 @@
 import { pool } from "../db";
 import { writeAuditLog } from "./audit.service";
+import type { Campaign, CampaignFilters } from "../types";
 
-export interface Campaign {
-  id: number;
-  merchant: string;
-  owner_address: string;
-  name?: string | null;
-  reward_amount: number;
-  expiration: number;
-  active: boolean;
-  total_claimed: number;
-  display_order: number;
-  tx_hash?: string;
-  image_url?: string;
-  created_at: Date;
-  deleted_at?: Date | null;
-}
+export type { Campaign, CampaignFilters };
 
 /**
  * Inserts or updates a campaign row and writes an audit log entry in one transaction.
@@ -84,14 +71,6 @@ export async function getCampaignImageByTxHash(txHash: string): Promise<string |
     [txHash]
   );
   return rows[0]?.image_url ?? null;
-}
-
-export interface CampaignFilters {
-  search?: string;
-  status?: "active" | "inactive";
-  expires_before?: number;
-  expires_after?: number;
-  owner?: string;
 }
 
 /**

--- a/backend/src/services/reward.service.ts
+++ b/backend/src/services/reward.service.ts
@@ -1,18 +1,8 @@
 import { pool } from "../db";
 import { logger } from "../logger";
+import type { Reward } from "../types";
 
-export interface Reward {
-  id: string;
-  user_address: string;
-  campaign_id: number;
-  amount: number;
-  redeemed: boolean;
-  redeemed_amount: number;
-  claimed_at: Date;
-  redeemed_at?: Date;
-  tx_hash?: string | null;
-  campaign_reward?: number;
-}
+export type { Reward };
 
 interface ExplainRow {
   "QUERY PLAN": string;

--- a/backend/src/services/transaction.service.ts
+++ b/backend/src/services/transaction.service.ts
@@ -1,15 +1,7 @@
 import { pool } from "../db";
+import type { TransactionRecord } from "../types";
 
-export interface TransactionRecord {
-  tx_hash: string;
-  type: string;
-  user_address: string;
-  campaign_id: number | null;
-  campaign_name: string | null;
-  amount: number;
-  ledger: number;
-  created_at: Date;
-}
+export type { TransactionRecord };
 
 /**
  * Lists indexed on-chain transactions for a user with campaign context.

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,0 +1,199 @@
+/**
+ * @module types
+ * Central type definitions for the Soroban Loyalty backend.
+ *
+ * Import from this module instead of defining types inline in service files:
+ * ```ts
+ * import type { Campaign, Reward, TransactionRecord } from "@/types";
+ * ```
+ */
+
+// ── Campaign ──────────────────────────────────────────────────────────────────
+
+/**
+ * A loyalty campaign created by a merchant on the Soroban contract.
+ * Rows are indexed from on-chain events and stored in the `campaigns` table.
+ */
+export interface Campaign {
+  /** Auto-incremented on-chain campaign identifier. */
+  id: number;
+  /** Stellar public key of the merchant who created the campaign. */
+  merchant: string;
+  /** Stellar public key used for ownership checks (defaults to `merchant`). */
+  owner_address: string;
+  /** Optional human-readable campaign name. */
+  name?: string | null;
+  /** Number of LYT tokens awarded per claim. */
+  reward_amount: number;
+  /** Unix timestamp (seconds) at which the campaign expires. */
+  expiration: number;
+  /** Whether the campaign is currently accepting new claims. */
+  active: boolean;
+  /** Running total of reward claims. */
+  total_claimed: number;
+  /** Sort position in the merchant dashboard (lower = higher). */
+  display_order: number;
+  /** On-chain transaction hash from the campaign-creation event. */
+  tx_hash?: string;
+  /** Public URL of the campaign banner image. */
+  image_url?: string;
+  /** Timestamp when the row was first inserted. */
+  created_at: Date;
+  /** Timestamp of soft-deletion; null while the campaign is live. */
+  deleted_at?: Date | null;
+}
+
+/**
+ * Optional filters for {@link getCampaigns}.
+ * All fields are combined with AND logic.
+ */
+export interface CampaignFilters {
+  /** Case-insensitive substring match against the campaign `name`. */
+  search?: string;
+  /** Restrict results to active or inactive campaigns. */
+  status?: "active" | "inactive";
+  /** Only return campaigns that expire at or before this Unix timestamp. */
+  expires_before?: number;
+  /** Only return campaigns that expire at or after this Unix timestamp. */
+  expires_after?: number;
+  /** Filter by the merchant's Stellar public key (`owner_address`). */
+  owner?: string;
+}
+
+// ── Reward ────────────────────────────────────────────────────────────────────
+
+/**
+ * A reward earned by a user for claiming a campaign.
+ * Rows are stored in the `rewards` table and updated when redeemed.
+ */
+export interface Reward {
+  /** UUID primary key. */
+  id: string;
+  /** Stellar public key of the reward owner. */
+  user_address: string;
+  /** ID of the campaign this reward belongs to. */
+  campaign_id: number;
+  /** LYT amount awarded at claim time. */
+  amount: number;
+  /** Whether any portion of the reward has been redeemed (burned). */
+  redeemed: boolean;
+  /** LYT amount already burned via redeem. */
+  redeemed_amount: number;
+  /** Timestamp when the reward was claimed. */
+  claimed_at: Date;
+  /** Timestamp when the reward was redeemed; absent if not yet redeemed. */
+  redeemed_at?: Date;
+  /** On-chain transaction hash for the claim event; null for legacy rows. */
+  tx_hash?: string | null;
+  /** `reward_amount` from the parent campaign, joined at query time. */
+  campaign_reward?: number;
+}
+
+// ── Transaction ───────────────────────────────────────────────────────────────
+
+/**
+ * An indexed on-chain transaction stored in the `transactions` table.
+ */
+export interface TransactionRecord {
+  /** Unique on-chain transaction hash. */
+  tx_hash: string;
+  /** Event type: `"claim"`, `"redeem"`, or `"create_campaign"`. */
+  type: string;
+  /** Stellar public key of the user involved. */
+  user_address: string;
+  /** ID of the related campaign, or null for non-campaign transactions. */
+  campaign_id: number | null;
+  /** Campaign name joined from the campaigns table, or null. */
+  campaign_name: string | null;
+  /** Token amount involved; 0 for events with no token transfer. */
+  amount: number;
+  /** Ledger sequence number when the transaction was finalized. */
+  ledger: number;
+  /** Timestamp when the row was inserted by the indexer. */
+  created_at: Date;
+}
+
+// ── Analytics ─────────────────────────────────────────────────────────────────
+
+/**
+ * Aggregated reward-claim metrics returned by the analytics endpoint.
+ */
+export interface AnalyticsData {
+  /** Total number of reward claims in the requested time window. */
+  totalClaims: number;
+  /** Total LYT tokens issued across all claims. */
+  totalLYT: number;
+  /** Percentage of claims that have been redeemed (0–100). */
+  redemptionRate: number;
+  /** Top campaigns by claim count, for bar-chart display. */
+  claimsPerCampaign: { name: string; claims: number }[];
+  /** Daily claim counts over the time window, for line-chart display. */
+  claimsOverTime: { date: string; claims: number }[];
+}
+
+/**
+ * Broader campaign-level analytics, cached in Redis for 5 minutes.
+ */
+export interface CampaignAnalyticsData {
+  /** Total number of campaigns in the database. */
+  total_campaigns: number;
+  /** Total claims in the last 30 days. */
+  total_claims: number;
+  /** Daily claim counts for the last 30 days. */
+  claims_per_day: { date: string; count: number }[];
+  /** Top 5 campaigns by claim count in the last 30 days. */
+  top_campaigns: { campaign_id: number; claims: number }[];
+}
+
+// ── Audit ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Permitted values for the `action` field of an {@link AuditLogEntry}.
+ */
+export type AuditAction =
+  | "campaign.create"
+  | "campaign.deactivate"
+  | "reward.claim"
+  | "reward.redeem";
+
+/**
+ * A single audit log entry recording a privileged or on-chain-derived action.
+ */
+export interface AuditLogEntry {
+  /** UUID primary key. */
+  id: string;
+  /** Stellar public key of the merchant or system actor. */
+  actor: string;
+  /** Categorised action that was performed. */
+  action: AuditAction;
+  /** Domain entity type, e.g. `"campaign"` or `"reward"`. */
+  entity_type: string;
+  /** String representation of the entity's primary key. */
+  entity_id: string;
+  /** Free-form metadata snapshot captured at the time of the action. */
+  metadata: Record<string, unknown>;
+  /** Timestamp when the log entry was written. */
+  created_at: Date;
+}
+
+/**
+ * Optional filters for {@link queryAuditLogs}.
+ */
+export interface AuditLogFilters {
+  /** Filter by actor public key. */
+  actor?: string;
+  /** Filter by action type. */
+  action?: AuditAction;
+  /** Filter by entity domain (e.g. `"campaign"`). */
+  entity_type?: string;
+  /** Filter by specific entity ID. */
+  entity_id?: string;
+  /** Only include entries created at or after this date. */
+  since?: Date;
+  /** Only include entries created at or before this date. */
+  until?: Date;
+  /** Maximum rows to return (default 50). */
+  limit?: number;
+  /** Rows to skip for pagination (default 0). */
+  offset?: number;
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -12,45 +12,7 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-export interface Campaign {
-  id: number;
-  merchant: string;
-  name?: string | null;
-  reward_amount: number;
-  expiration: number;
-  active: boolean;
-  total_claimed: number;
-  image_url?: string;
-}
-
-export interface Reward {
-  id: string;
-  user_address: string;
-  campaign_id: number;
-  amount: number;
-  redeemed: boolean;
-  redeemed_amount: number;
-  claimed_at: string;
-}
-
-export interface AnalyticsData {
-  totalClaims: number;
-  totalLYT: number;
-  redemptionRate: number;
-  claimsPerCampaign: { name: string; claims: number }[];
-  claimsOverTime: { date: string; claims: number }[];
-}
-
-export interface TransactionRecord {
-  tx_hash: string;
-  type: string;
-  user_address: string;
-  campaign_id: number | null;
-  campaign_name: string | null;
-  amount: number;
-  ledger: number;
-  created_at: string;
-}
+export type { Campaign, Reward, AnalyticsData, TransactionRecord } from "@/types";
 
 export const api = {
   getCampaigns: (limit = 20, offset = 0) =>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,107 @@
+/**
+ * @module types
+ * Central type definitions for the Soroban Loyalty frontend.
+ *
+ * These types mirror the backend API response shapes. Import from here instead
+ * of relying on inline definitions in `lib/api.ts` or component files:
+ * ```ts
+ * import type { Campaign, Reward, TransactionRecord } from "@/types";
+ * ```
+ *
+ * ### Differences from backend types
+ * - Date fields arrive from the REST API as ISO-8601 strings, not `Date` objects.
+ * - `Campaign` omits server-only fields (`owner_address`, `display_order`,
+ *   `created_at`, `deleted_at`, `tx_hash`).
+ * - `Reward` omits indexer-only fields (`redeemed_at`, `tx_hash`, `campaign_reward`).
+ * - `TransactionRecord` adds `campaign_name` (joined by the backend query).
+ */
+
+// ── Campaign ──────────────────────────────────────────────────────────────────
+
+/**
+ * A loyalty campaign as returned by `GET /campaigns` and `GET /campaigns/:id`.
+ */
+export interface Campaign {
+  /** Numeric on-chain campaign identifier. */
+  id: number;
+  /** Stellar public key of the merchant who created the campaign. */
+  merchant: string;
+  /** Optional human-readable campaign name. */
+  name?: string | null;
+  /** LYT tokens awarded per claim. */
+  reward_amount: number;
+  /** Unix timestamp (seconds) at which the campaign expires. */
+  expiration: number;
+  /** Whether the campaign is currently accepting new claims. */
+  active: boolean;
+  /** Running total of reward claims. */
+  total_claimed: number;
+  /** Public URL of the campaign banner image. */
+  image_url?: string;
+}
+
+// ── Reward ────────────────────────────────────────────────────────────────────
+
+/**
+ * A reward earned by the connected user, as returned by
+ * `GET /user/:address/rewards`.
+ */
+export interface Reward {
+  /** UUID primary key. */
+  id: string;
+  /** Stellar public key of the reward owner. */
+  user_address: string;
+  /** ID of the campaign this reward belongs to. */
+  campaign_id: number;
+  /** LYT amount awarded at claim time. */
+  amount: number;
+  /** Whether any portion of the reward has been redeemed (burned). */
+  redeemed: boolean;
+  /** LYT amount already burned via redeem. */
+  redeemed_amount: number;
+  /** ISO-8601 timestamp when the reward was claimed. */
+  claimed_at: string;
+}
+
+// ── Analytics ─────────────────────────────────────────────────────────────────
+
+/**
+ * Aggregated metrics returned by `GET /analytics?days=N`.
+ */
+export interface AnalyticsData {
+  /** Total reward claims in the requested time window. */
+  totalClaims: number;
+  /** Total LYT tokens issued across all claims. */
+  totalLYT: number;
+  /** Percentage of claims that have been redeemed (0–100). */
+  redemptionRate: number;
+  /** Top campaigns by claim count, for bar-chart display. */
+  claimsPerCampaign: { name: string; claims: number }[];
+  /** Daily claim counts over the time window, for line-chart display. */
+  claimsOverTime: { date: string; claims: number }[];
+}
+
+// ── Transaction ───────────────────────────────────────────────────────────────
+
+/**
+ * An indexed on-chain transaction as returned by
+ * `GET /user/:address/transactions`.
+ */
+export interface TransactionRecord {
+  /** Unique on-chain transaction hash. */
+  tx_hash: string;
+  /** Event type: `"claim"`, `"redeem"`, or `"create_campaign"`. */
+  type: string;
+  /** Stellar public key of the user involved. */
+  user_address: string;
+  /** ID of the related campaign, or null. */
+  campaign_id: number | null;
+  /** Campaign name joined by the backend, or null. */
+  campaign_name: string | null;
+  /** Token amount involved. */
+  amount: number;
+  /** Ledger sequence number when the transaction was finalized. */
+  ledger: number;
+  /** ISO-8601 timestamp when the indexer recorded the transaction. */
+  created_at: string;
+}


### PR DESCRIPTION
- Add backend/src/types/index.ts with JSDoc for all shared types
- Add frontend/src/types/index.ts with JSDoc for API response types
- Refactor services to import from central types (re-export for compat)
- Update frontend/src/lib/api.ts to re-export types from @/types
- Expand README API Reference with types table and response types

## Pull Request Checklist

Before submitting your PR, please review the following checklist:

- [ ] I have run tests locally and they all pass.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have added appropriate tests for new features or bug fixes.
- [ ] **Smart Contract Changes**: If I modified anything under `contracts/`, I updated `docs/audits/smart-contract-audit-status.yml` to reflect whether a re-audit is now required.
- [ ] **Database Schema Changes**: If I altered `schema.sql`, I have:
  - [ ] Updated the ERD (`docs/erd.png`).
  - [ ] Updated the schema documentation in `docs/database.md`.
- [ ] Runbook / Operations documentation is updated if necessary.
- [ ] **Changelog & Versioning**:
  - [ ] I have updated the `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/) format.
  - [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `BREAKING CHANGE:`).


closes #353