### PR TITLE
feat: improve form field focus and error styling (#356)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -461,6 +461,42 @@ body {
 .alert-success { background: var(--alert-success-bg); color: var(--alert-success-color); border: 1px solid var(--alert-success-border); }
 .form-group { display: flex; flex-direction: column; gap: 6px; margin-bottom: 16px; }
 .form-group label { font-size: 0.875rem; color: var(--text-secondary); }
+
+/* ── Form input (shared base for all text/number/date inputs) ─────────────── */
+.form-input {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  width: 100%;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.form-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.form-input--error {
+  border-color: #dc2626;
+}
+.form-input--error:focus {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 2px rgba(220, 38, 38, 0.3);
+}
+
+/* ── Field-level error message ────────────────────────────────────────────── */
+.form-field-error {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: #f87171;
+}
+[data-theme="light"] .form-field-error { color: #dc2626; }
+
+/* Legacy: keep .form-group input for any unsupported inputs not using .form-input */
 .form-group input {
   background: var(--bg-input);
   border: 1px solid var(--border);

--- a/frontend/src/components/CreateCampaignForm.tsx
+++ b/frontend/src/components/CreateCampaignForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { createCampaign } from "@/lib/soroban";
+import { Input } from "@/components/Input";
 
 interface Props {
   publicKey: string;
@@ -139,45 +140,36 @@ export function CreateCampaignForm({ publicKey, onSuccess }: Props) {
     <form onSubmit={handleReview} style={{ maxWidth: 480 }} noValidate>
       {txError && <div className="alert alert-error">{txError}</div>}
 
-      <div className="form-group">
-        <label htmlFor="ccf-name">Campaign Name</label>
-        <input
-          id="ccf-name"
-          type="text"
-          value={fields.name}
-          onChange={set("name")}
-          placeholder="e.g. Summer Rewards"
-          aria-describedby={errors.name ? "ccf-name-err" : undefined}
-        />
-        {errors.name && <span id="ccf-name-err" style={{ fontSize: "0.8rem", color: "#f87171" }}>{errors.name}</span>}
-      </div>
+      <Input
+        id="ccf-name"
+        label="Campaign Name"
+        type="text"
+        value={fields.name}
+        onChange={set("name")}
+        placeholder="e.g. Summer Rewards"
+        error={errors.name}
+      />
 
-      <div className="form-group">
-        <label htmlFor="ccf-amount">Reward Amount (LYT)</label>
-        <input
-          id="ccf-amount"
-          type="number"
-          min="1"
-          value={fields.rewardAmount}
-          onChange={set("rewardAmount")}
-          placeholder="e.g. 100"
-          aria-describedby={errors.rewardAmount ? "ccf-amount-err" : undefined}
-        />
-        {errors.rewardAmount && <span id="ccf-amount-err" style={{ fontSize: "0.8rem", color: "#f87171" }}>{errors.rewardAmount}</span>}
-      </div>
+      <Input
+        id="ccf-amount"
+        label="Reward Amount (LYT)"
+        type="number"
+        min="1"
+        value={fields.rewardAmount}
+        onChange={set("rewardAmount")}
+        placeholder="e.g. 100"
+        error={errors.rewardAmount}
+      />
 
-      <div className="form-group">
-        <label htmlFor="ccf-expires">Expiration Date</label>
-        <input
-          id="ccf-expires"
-          type="date"
-          min={today()}
-          value={fields.expiresAt}
-          onChange={set("expiresAt")}
-          aria-describedby={errors.expiresAt ? "ccf-expires-err" : undefined}
-        />
-        {errors.expiresAt && <span id="ccf-expires-err" style={{ fontSize: "0.8rem", color: "#f87171" }}>{errors.expiresAt}</span>}
-      </div>
+      <Input
+        id="ccf-expires"
+        label="Expiration Date"
+        type="date"
+        min={today()}
+        value={fields.expiresAt}
+        onChange={set("expiresAt")}
+        error={errors.expiresAt}
+      />
 
       <button type="submit" className="btn btn-primary">
         Review Campaign

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -1,0 +1,38 @@
+import { InputHTMLAttributes } from "react";
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  id: string;
+  label: string;
+  error?: string;
+}
+
+export function Input({ id, label, error, className, ...props }: InputProps) {
+  const errorId = error ? `${id}-err` : undefined;
+  return (
+    <div className="form-group">
+      <label htmlFor={id}>{label}</label>
+      <input
+        id={id}
+        aria-invalid={!!error}
+        aria-describedby={errorId}
+        className={`form-input${error ? " form-input--error" : ""}${className ? ` ${className}` : ""}`}
+        {...props}
+      />
+      {error && (
+        <span id={errorId} className="form-field-error" role="alert">
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+          >
+            <path d="M8 1a7 7 0 1 0 0 14A7 7 0 0 0 8 1zm.75 3.5v4a.75.75 0 0 1-1.5 0v-4a.75.75 0 0 1 1.5 0zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z" />
+          </svg>
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/RedeemForm.tsx
+++ b/frontend/src/components/RedeemForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useSorobanTransaction } from "@/hooks/useSorobanTransaction";
 import { SorobanErrorBoundary } from "./SorobanErrorBoundary";
 import { ConfirmDialog } from "./ConfirmDialog";
+import { Input } from "@/components/Input";
 
 interface Props {
   balance: number;
@@ -56,23 +57,20 @@ function RedeemFormContent({ balance, onRedeem }: Props) {
           </div>
         )}
 
-        <div className="form-group">
-          <label>Amount to Redeem (LYT)</label>
-          <input
-            type="number"
-            min="1"
-            max={balance}
-            value={amount}
-            onChange={(e) => setAmount(e.target.value)}
-            placeholder={`Max ${balance.toLocaleString()}`}
-            disabled={loading}
-          />
-          {amount && !isValid && (
-            <span style={{ fontSize: "0.8rem", color: "#f87171" }}>
-              {parsed > balance ? "Exceeds balance" : "Enter a valid amount"}
-            </span>
-          )}
-        </div>
+        <Input
+          id="redeem-amount"
+          label="Amount to Redeem (LYT)"
+          type="number"
+          min="1"
+          max={balance}
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder={`Max ${balance.toLocaleString()}`}
+          disabled={loading}
+          error={amount && !isValid
+            ? (parsed > balance ? "Exceeds balance" : "Enter a valid amount")
+            : undefined}
+        />
 
         <button
           className="btn btn-primary"


### PR DESCRIPTION
- Add reusable Input component with focus ring and error state
- Focus ring uses brand accent color (var(--accent)) with 2px box-shadow
- Error state shows red border, warning icon, and message below field
- Add aria-invalid and aria-describedby for accessibility
- Replace raw inputs in CreateCampaignForm and RedeemForm

## Pull Request Checklist

Before submitting your PR, please review the following checklist:

- [ ] I have run tests locally and they all pass.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have added appropriate tests for new features or bug fixes.
- [ ] **Smart Contract Changes**: If I modified anything under `contracts/`, I updated `docs/audits/smart-contract-audit-status.yml` to reflect whether a re-audit is now required.
- [ ] **Database Schema Changes**: If I altered `schema.sql`, I have:
  - [ ] Updated the ERD (`docs/erd.png`).
  - [ ] Updated the schema documentation in `docs/database.md`.
- [ ] Runbook / Operations documentation is updated if necessary.
- [ ] **Changelog & Versioning**:
  - [ ] I have updated the `CHANGELOG.md` following the [Keep a Changelog](https://keepachangelog.com/) format.
  - [ ] My PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `BREAKING CHANGE:`).


closes #356 